### PR TITLE
Prevent mobile auto-zoom on input focus

### DIFF
--- a/client/web/biome.json
+++ b/client/web/biome.json
@@ -38,6 +38,11 @@
       "indentWidth": 2
     }
   },
+  "css": {
+    "parser": {
+      "tailwindDirectives": true
+    }
+  },
   "overrides": [
     {
       "includes": ["**/*.svelte"],

--- a/client/web/src/components/AuditLogTab.svelte
+++ b/client/web/src/components/AuditLogTab.svelte
@@ -230,7 +230,7 @@ function resourceCopyTarget(entry: V2AuditEvent): { value: string; label: string
         <label class="flex min-w-56 flex-col gap-1.5 text-xs font-medium text-neutral-600 dark:text-neutral-300">
             Event
             <select
-                class="h-9 rounded-lg border border-neutral-300 bg-white px-3 text-[13px] text-neutral-900 outline-none transition focus:border-neutral-900 focus:ring-2 focus:ring-neutral-200 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-50 dark:focus:border-neutral-300 dark:focus:ring-neutral-800"
+                class="h-9 rounded-lg border border-neutral-300 bg-white px-3 text-[13px] coarse:text-base text-neutral-900 outline-none transition focus:border-neutral-900 focus:ring-2 focus:ring-neutral-200 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-50 dark:focus:border-neutral-300 dark:focus:ring-neutral-800"
                 value={selectedEventType}
                 onchange={handleEventTypeChange}
                 disabled={auditLoading}

--- a/client/web/src/components/SigningKeysTab.svelte
+++ b/client/web/src/components/SigningKeysTab.svelte
@@ -258,7 +258,7 @@ function isDerivedPublished(): boolean {
                     id="signing-key-algorithm"
                     bind:value={deriveAlgorithm}
                     disabled={busy || derivingKey}
-                    class="h-10.5 w-full rounded-lg border border-neutral-300 bg-white px-3 text-sm text-neutral-950 outline-none transition focus:border-neutral-900 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-50 dark:focus:border-neutral-300"
+                    class="h-10.5 w-full rounded-lg border border-neutral-300 bg-white px-3 text-sm coarse:text-base text-neutral-950 outline-none transition focus:border-neutral-900 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-50 dark:focus:border-neutral-300"
                 >
                     {#each SIGNING_ALGORITHMS as alg}
                         <option value={alg}>{alg}</option>

--- a/client/web/src/components/TextField.svelte
+++ b/client/web/src/components/TextField.svelte
@@ -41,6 +41,6 @@ let {
     {required}
     {type}
     bind:value
-    class={`h-10.5 w-full rounded-lg border border-neutral-300 bg-white px-3 text-sm text-neutral-900 outline-none transition-colors focus:border-neutral-900 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-50 dark:focus:border-neutral-300 ${className}`}
+    class={`h-10.5 w-full rounded-lg border border-neutral-300 bg-white px-3 text-sm coarse:text-base text-neutral-900 outline-none transition-colors focus:border-neutral-900 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-50 dark:focus:border-neutral-300 ${className}`}
     oninput={oninput}
 />

--- a/client/web/src/components/UserSettingsModal.svelte
+++ b/client/web/src/components/UserSettingsModal.svelte
@@ -425,7 +425,7 @@ const tabs: { id: SettingsTab; label: string; icon: string }[] = [
                     </div>
 
                     <textarea
-                        class="mono min-h-40 w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-950 outline-none transition focus:border-neutral-900 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-50 dark:focus:border-neutral-300"
+                        class="mono min-h-40 w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm coarse:text-base text-neutral-950 outline-none transition focus:border-neutral-900 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-50 dark:focus:border-neutral-300"
                         value={allowedIpsText}
                         oninput={(event) => {
                             onAllowedIpsTextInput((event.currentTarget as HTMLTextAreaElement).value)

--- a/client/web/src/style.css
+++ b/client/web/src/style.css
@@ -2,6 +2,12 @@
 @import "@fontsource-variable/geist-mono/wght.css";
 @import "tailwindcss";
 
+/* Variant for coarse pointers (touch devices). Used to bump form fields up to
+   16px on phones/tablets: iOS Safari (and some Android browsers) auto-zoom the
+   viewport when a focused field has a font-size below 16px, which otherwise
+   leaves the page zoomed in after signing in. */
+@custom-variant coarse (@media (pointer: coarse));
+
 :root {
     color-scheme: light dark;
     --app-bg: #fafafa;
@@ -59,21 +65,6 @@ kbd,
 pre,
 samp {
     font-family: "Geist Mono Variable", "Geist Mono", ui-monospace, Menlo, monospace;
-}
-
-/* iOS Safari (and some Android browsers) automatically zoom the viewport in
-   when a form field whose font-size is below 16px receives focus. Our inputs
-   use `text-sm` (14px) for a tighter look, which triggers this zoom on touch
-   devices and leaves the user zoomed in after signing in, forcing them to zoom
-   back out by hand. On coarse-pointer (touch) devices, bump form controls to
-   16px to suppress the auto-zoom. `!important` is needed to win over Tailwind's
-   font-size utilities. */
-@media (pointer: coarse) {
-    input,
-    select,
-    textarea {
-        font-size: 16px !important;
-    }
 }
 
 ::selection {

--- a/client/web/src/style.css
+++ b/client/web/src/style.css
@@ -2,10 +2,8 @@
 @import "@fontsource-variable/geist-mono/wght.css";
 @import "tailwindcss";
 
-/* Variant for coarse pointers (touch devices). Used to bump form fields up to
-   16px on phones/tablets: iOS Safari (and some Android browsers) auto-zoom the
-   viewport when a focused field has a font-size below 16px, which otherwise
-   leaves the page zoomed in after signing in. */
+/* Variant for coarse pointers (touch devices)
+   Used to bump form fields up to 16px on phones/tablets: iOS Safari (and some Android browsers) auto-zoom the viewport when a focused field has a font-size below 16px, which otherwise leaves the page zoomed in after signing in */
 @custom-variant coarse (@media (pointer: coarse));
 
 :root {

--- a/client/web/src/style.css
+++ b/client/web/src/style.css
@@ -61,6 +61,21 @@ samp {
     font-family: "Geist Mono Variable", "Geist Mono", ui-monospace, Menlo, monospace;
 }
 
+/* iOS Safari (and some Android browsers) automatically zoom the viewport in
+   when a form field whose font-size is below 16px receives focus. Our inputs
+   use `text-sm` (14px) for a tighter look, which triggers this zoom on touch
+   devices and leaves the user zoomed in after signing in, forcing them to zoom
+   back out by hand. On coarse-pointer (touch) devices, bump form controls to
+   16px to suppress the auto-zoom. `!important` is needed to win over Tailwind's
+   font-size utilities. */
+@media (pointer: coarse) {
+    input,
+    select,
+    textarea {
+        font-size: 16px !important;
+    }
+}
+
 ::selection {
     background: oklch(0.85 0.1 252);
     color: #0a0a0a;


### PR DESCRIPTION
iOS Safari (and some Android browsers) automatically zoom the viewport in when a focused form field has a font-size below 16px. The shared inputs use text-sm (14px), so signing in on a phone left the page zoomed in and required zooming back out by hand.

Add a global rule that bumps form controls to 16px on coarse-pointer
(touch) devices, which suppresses the auto-zoom while keeping the tighter 14px sizing on desktop.