### PR TITLE
Support versioned pubkey bundle signatures for epoch-independent verification

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,13 +33,13 @@ jobs:
 
     env:
       CGO_ENABLED: "0"
-      GOLANGCI_LINT_VERSION: "v2.11.4"
+      GOLANGCI_LINT_VERSION: "v2.12.2"
       GOEXPERIMENT: jsonv2
       TEST_POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/revaulter_test?sslmode=disable
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - uses: actions/setup-go@v6
         with:
@@ -58,8 +58,7 @@ jobs:
 
       - name: Check Go dependency minimum age
         run: |
-          go install github.com/fchimpan/gomod-age@09005169a4792ad1a4824e1fc6d85785d91cea36
-          gomod-age
+          go tool gomod-age
 
       - name: Install client dependencies
         working-directory: client/web

--- a/.github/workflows/refresh-sigstore-trust-root.yaml
+++ b/.github/workflows/refresh-sigstore-trust-root.yaml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Download latest trust root
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
     steps:
 
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - uses: actions/setup-go@v6
         with:

--- a/client/web/src/components/App.svelte
+++ b/client/web/src/components/App.svelte
@@ -24,6 +24,7 @@ import {
     anchorEs384JwkToString,
     anchorMldsa87PubToString,
     generateAnchorKeyPair,
+    PUBKEY_BUNDLE_VERSION,
     SIGNING_KEY_PUBLICATION_VERSION,
     serializeAnchorSecret,
     signCredentialAttestationHybrid,
@@ -534,7 +535,7 @@ async function doSetPassword() {
             anchorEs384X: anchor.es384.publicKeyJwk.x,
             anchorEs384Y: anchor.es384.publicKeyJwk.y,
             anchorMldsa87PublicKey: anchorMldsa87Str,
-            wrappedKeyEpoch: 1,
+            v: PUBKEY_BUNDLE_VERSION,
         })
 
         // Sign the first-credential attestation with the fresh anchor.
@@ -554,6 +555,7 @@ async function doSetPassword() {
             anchorMldsa87PublicKey: anchorMldsa87Str,
             pubkeyBundleSignatureEs384: bundleSig.sigEs384,
             pubkeyBundleSignatureMldsa87: bundleSig.sigMldsa87,
+            pubkeyBundleVersion: PUBKEY_BUNDLE_VERSION,
             wrappedAnchorKey: wrappedAnchor,
             attestationPayload: attestSig.canonicalBody,
             attestationSignatureEs384: attestSig.sigEs384,

--- a/client/web/src/lib/crypto-anchor.test.ts
+++ b/client/web/src/lib/crypto-anchor.test.ts
@@ -8,6 +8,7 @@ import {
     attestationPayloadCanonicalBody,
     generateAnchorKeyPair,
     type PubkeyBundlePayload,
+    PUBKEY_BUNDLE_VERSION,
     parseAnchorSecret,
     parseWrappedAnchorEnvelope,
     pubkeyBundlePayloadCanonicalBody,
@@ -128,13 +129,14 @@ describe('hybrid attestation signatures', () => {
             anchorEs384X: kp.es384.publicKeyJwk.x,
             anchorEs384Y: kp.es384.publicKeyJwk.y,
             anchorMldsa87PublicKey: anchorMldsa87PubToString(kp.mldsa87.publicKey),
-            wrappedKeyEpoch: 1,
+            v: PUBKEY_BUNDLE_VERSION,
         })
         expect(sig.sigEs384).toBeTruthy()
         expect(sig.sigMldsa87).toBeTruthy()
     })
 
     it('produces a stable canonical pubkey bundle body with ordered key=value lines', () => {
+        // This must byte-match the expected body in pkg/protocolv2/anchor_test.go::TestPubkeyBundlePayloadV2CanonicalBody (modulo values)
         const payload: PubkeyBundlePayload = {
             userId: 'u-1',
             requestEncEcdhPubkey: 'ecdh',
@@ -144,7 +146,7 @@ describe('hybrid attestation signatures', () => {
             anchorEs384X: 'aaa',
             anchorEs384Y: 'bbb',
             anchorMldsa87PublicKey: 'mldsa87',
-            wrappedKeyEpoch: 2,
+            v: PUBKEY_BUNDLE_VERSION,
         }
         expect(pubkeyBundlePayloadCanonicalBody(payload)).toBe(
             [
@@ -156,7 +158,7 @@ describe('hybrid attestation signatures', () => {
                 'anchorEs384X=aaa',
                 'anchorEs384Y=bbb',
                 'anchorMldsa87PublicKey=mldsa87',
-                'wrappedKeyEpoch=2',
+                'v=2',
             ].join('\n')
         )
     })

--- a/client/web/src/lib/crypto-anchor.test.ts
+++ b/client/web/src/lib/crypto-anchor.test.ts
@@ -136,7 +136,7 @@ describe('hybrid attestation signatures', () => {
     })
 
     it('produces a stable canonical pubkey bundle body with ordered key=value lines', () => {
-        // This must byte-match the expected body in pkg/protocolv2/anchor_test.go::TestPubkeyBundlePayloadV2CanonicalBody (modulo values)
+        // This must byte-match the expected body in pkg/protocolv2/anchor_test.go TestPubkeyBundlePayloadV2CanonicalBody (modulo values)
         const payload: PubkeyBundlePayload = {
             userId: 'u-1',
             requestEncEcdhPubkey: 'ecdh',

--- a/client/web/src/lib/crypto-anchor.ts
+++ b/client/web/src/lib/crypto-anchor.ts
@@ -55,7 +55,8 @@ export type AttestationPayload = {
 }
 
 // PubkeyBundlePayload mirrors pkg/protocolv2.PubkeyBundlePayloadV2
-// The web client only ever produces new bundles, so it always signs the v2 shape; the legacy v1 shape (wrappedKeyEpoch line instead of v) exists only on rows created by older releases and is verified server- and CLI-side
+// The web client only ever produces new bundles, so it always signs the v2 shape
+// The legacy v1 shape (wrappedKeyEpoch line instead of v) exists only on rows created by older releases and is verified server- and CLI-side
 export type PubkeyBundlePayload = {
     userId: string
     requestEncEcdhPubkey: string

--- a/client/web/src/lib/crypto-anchor.ts
+++ b/client/web/src/lib/crypto-anchor.ts
@@ -15,6 +15,11 @@ const SIGNING_KEY_PUBLICATION_PREFIX = 'revaulter/v2/signing-key-publication\n'
 // Bump only when the canonical body shape changes in a backwards-incompatible way
 export const SIGNING_KEY_PUBLICATION_VERSION = 1
 
+// Version mirrored from pkg/protocolv2.PubkeyBundleVersion2
+// New signups always sign the v2 payload, which binds an explicit `v` line instead of the legacy wrappedKeyEpoch (that epoch tracked unrelated key re-wraps and was always 1 in the signed bytes)
+// The version is sent alongside the signatures at finalize-signup so the server and CLI reconstruct the exact signed payload
+export const PUBKEY_BUNDLE_VERSION = 2
+
 // Fixed sizes mirrored from pkg/protocolv2.
 const P384_COORD_SIZE = 48
 const ES384_SIG_SIZE = 96
@@ -49,6 +54,8 @@ export type AttestationPayload = {
     createdAt: number
 }
 
+// PubkeyBundlePayload mirrors pkg/protocolv2.PubkeyBundlePayloadV2
+// The web client only ever produces new bundles, so it always signs the v2 shape; the legacy v1 shape (wrappedKeyEpoch line instead of v) exists only on rows created by older releases and is verified server- and CLI-side
 export type PubkeyBundlePayload = {
     userId: string
     requestEncEcdhPubkey: string
@@ -58,7 +65,7 @@ export type PubkeyBundlePayload = {
     anchorEs384X: string
     anchorEs384Y: string
     anchorMldsa87PublicKey: string
-    wrappedKeyEpoch: number
+    v: number
 }
 
 // SigningKeyPublicationPayload mirrors pkg/protocolv2.SigningKeyPublicationPayload
@@ -328,7 +335,7 @@ function canonicalAttestationMessage(body: string): Uint8Array {
  * This is the body that (with the domain-separation prefix) is signed by both anchor legs
  */
 export function pubkeyBundlePayloadCanonicalBody(payload: PubkeyBundlePayload): string {
-    // Field order must exactly match pkg/protocolv2.PubkeyBundlePayload canonical body
+    // Field order must exactly match pkg/protocolv2.PubkeyBundlePayloadV2 canonical body
     return [
         `userId=${payload.userId}`,
         `requestEncEcdhPubkey=${payload.requestEncEcdhPubkey}`,
@@ -338,7 +345,7 @@ export function pubkeyBundlePayloadCanonicalBody(payload: PubkeyBundlePayload): 
         `anchorEs384X=${payload.anchorEs384X}`,
         `anchorEs384Y=${payload.anchorEs384Y}`,
         `anchorMldsa87PublicKey=${payload.anchorMldsa87PublicKey}`,
-        `wrappedKeyEpoch=${payload.wrappedKeyEpoch}`,
+        `v=${payload.v}`,
     ].join('\n')
 }
 

--- a/client/web/src/lib/v2-api.ts
+++ b/client/web/src/lib/v2-api.ts
@@ -64,6 +64,7 @@ export async function v2FinalizeSignup(args: {
     anchorMldsa87PublicKey: string
     pubkeyBundleSignatureEs384: string
     pubkeyBundleSignatureMldsa87: string
+    pubkeyBundleVersion: number
     wrappedAnchorKey: string
     attestationPayload: string
     attestationSignatureEs384: string
@@ -76,6 +77,7 @@ export async function v2FinalizeSignup(args: {
         anchorMldsa87PublicKey: args.anchorMldsa87PublicKey,
         pubkeyBundleSignatureEs384: args.pubkeyBundleSignatureEs384,
         pubkeyBundleSignatureMldsa87: args.pubkeyBundleSignatureMldsa87,
+        pubkeyBundleVersion: args.pubkeyBundleVersion,
         wrappedAnchorKey: args.wrappedAnchorKey,
         attestationPayload: args.attestationPayload,
         attestationSignatureEs384: args.attestationSignatureEs384,

--- a/cmd/cli/cmd/operations-v2.go
+++ b/cmd/cli/cmd/operations-v2.go
@@ -301,9 +301,12 @@ type v2PubkeyResponse struct {
 	EcdhP256 json.RawMessage `json:"ecdhP256"`
 	Mlkem768 string          `json:"mlkem768"`
 
-	AnchorEs384PublicKey         string `json:"anchorEs384PublicKey"`
-	AnchorMldsa87PublicKey       string `json:"anchorMldsa87PublicKey"`
-	WrappedKeyEpoch              int64  `json:"wrappedKeyEpoch"`
+	AnchorEs384PublicKey   string `json:"anchorEs384PublicKey"`
+	AnchorMldsa87PublicKey string `json:"anchorMldsa87PublicKey"`
+	// wrappedKeyEpoch is legacy and unused for verification: v1 bundle signatures always bind epoch 1, and servers that predate versioning echoed the user's live epoch here, so its value cannot be trusted
+	WrappedKeyEpoch int64 `json:"wrappedKeyEpoch"`
+	// pubkeyBundleVersion selects the canonical payload the signatures cover; servers that predate versioning omit it, which means v1
+	PubkeyBundleVersion          int64  `json:"pubkeyBundleVersion"`
 	PubkeyBundleSignatureEs384   string `json:"pubkeyBundleSignatureEs384"`
 	PubkeyBundleSignatureMldsa87 string `json:"pubkeyBundleSignatureMldsa87"`
 }

--- a/cmd/cli/cmd/operations-v2.go
+++ b/cmd/cli/cmd/operations-v2.go
@@ -301,14 +301,14 @@ type v2PubkeyResponse struct {
 	EcdhP256 json.RawMessage `json:"ecdhP256"`
 	Mlkem768 string          `json:"mlkem768"`
 
-	AnchorEs384PublicKey   string `json:"anchorEs384PublicKey"`
-	AnchorMldsa87PublicKey string `json:"anchorMldsa87PublicKey"`
-	// wrappedKeyEpoch is legacy and unused for verification: v1 bundle signatures always bind epoch 1, and servers that predate versioning echoed the user's live epoch here, so its value cannot be trusted
-	WrappedKeyEpoch int64 `json:"wrappedKeyEpoch"`
-	// pubkeyBundleVersion selects the canonical payload the signatures cover; servers that predate versioning omit it, which means v1
-	PubkeyBundleVersion          int64  `json:"pubkeyBundleVersion"`
+	AnchorEs384PublicKey         string `json:"anchorEs384PublicKey"`
+	AnchorMldsa87PublicKey       string `json:"anchorMldsa87PublicKey"`
 	PubkeyBundleSignatureEs384   string `json:"pubkeyBundleSignatureEs384"`
 	PubkeyBundleSignatureMldsa87 string `json:"pubkeyBundleSignatureMldsa87"`
+
+	// pubkeyBundleVersion selects the canonical payload the signatures cover
+	// Servers that predate versioning omit it, which means v1
+	PubkeyBundleVersion int64 `json:"pubkeyBundleVersion"`
 }
 
 func (o *v2OperationCmd) fetchAndVerifyUserPubkeys(ctx context.Context, httpClient *http.Client) (*ecdh.PublicKey, *mlkem.EncapsulationKey768, error) {

--- a/cmd/cli/cmd/trust-store.go
+++ b/cmd/cli/cmd/trust-store.go
@@ -188,24 +188,48 @@ func verifyAndPinAnchor(server string, resp *v2PubkeyResponse, ts *trustStore, c
 		return false, fmt.Errorf("invalid anchorEs384PublicKey: %w", err)
 	}
 
-	// The bundle signature is always bound to WrappedKeyEpoch = PubkeyBundleWrappedKeyEpoch (it is created once at signup and never re-signed), so the payload is reconstructed with that constant rather than the server-reported epoch
-	// Servers used to echo the user's live epoch here, which advances on password changes and would make verification fail for a signature that is still valid
-	bundlePayload := &protocolv2.PubkeyBundlePayload{
-		UserID:                 resp.UserID,
-		RequestEncEcdhPubkey:   string(resp.EcdhP256),
-		RequestEncMlkemPubkey:  resp.Mlkem768,
-		AnchorEs384Crv:         es384JWK.Crv,
-		AnchorEs384Kty:         es384JWK.Kty,
-		AnchorEs384X:           es384JWK.X,
-		AnchorEs384Y:           es384JWK.Y,
-		AnchorMldsa87PublicKey: resp.AnchorMldsa87PublicKey,
-		WrappedKeyEpoch:        protocolv2.PubkeyBundleWrappedKeyEpoch,
-	}
 	sigEs, sigMl, err := decodeHybridSignatures(resp.PubkeyBundleSignatureEs384, resp.PubkeyBundleSignatureMldsa87)
 	if err != nil {
 		return false, fmt.Errorf("invalid pubkey bundle signature: %w", err)
 	}
-	err = protocolv2.VerifyHybridBundle(es384Pub, mldsa87PubBytes, bundlePayload, sigEs, sigMl)
+
+	// The bundle is signed once at signup and never re-signed; the advertised pubkeyBundleVersion (absent on servers that predate versioning, meaning v1) selects the canonical payload to reconstruct
+	version := resp.PubkeyBundleVersion
+	if version == 0 {
+		version = protocolv2.PubkeyBundleVersion1
+	}
+	switch version {
+	case protocolv2.PubkeyBundleVersion1:
+		// Legacy payload: always bound to WrappedKeyEpoch = PubkeyBundleWrappedKeyEpoch, so it is reconstructed with that constant rather than the server-reported epoch
+		// Servers used to echo the user's live epoch in the response, which advances on password changes and would make verification fail for a signature that is still valid
+		bundlePayload := &protocolv2.PubkeyBundlePayload{
+			UserID:                 resp.UserID,
+			RequestEncEcdhPubkey:   string(resp.EcdhP256),
+			RequestEncMlkemPubkey:  resp.Mlkem768,
+			AnchorEs384Crv:         es384JWK.Crv,
+			AnchorEs384Kty:         es384JWK.Kty,
+			AnchorEs384X:           es384JWK.X,
+			AnchorEs384Y:           es384JWK.Y,
+			AnchorMldsa87PublicKey: resp.AnchorMldsa87PublicKey,
+			WrappedKeyEpoch:        protocolv2.PubkeyBundleWrappedKeyEpoch,
+		}
+		err = protocolv2.VerifyHybridBundle(es384Pub, mldsa87PubBytes, bundlePayload, sigEs, sigMl)
+	case protocolv2.PubkeyBundleVersion2:
+		bundlePayload := &protocolv2.PubkeyBundlePayloadV2{
+			UserID:                 resp.UserID,
+			RequestEncEcdhPubkey:   string(resp.EcdhP256),
+			RequestEncMlkemPubkey:  resp.Mlkem768,
+			AnchorEs384Crv:         es384JWK.Crv,
+			AnchorEs384Kty:         es384JWK.Kty,
+			AnchorEs384X:           es384JWK.X,
+			AnchorEs384Y:           es384JWK.Y,
+			AnchorMldsa87PublicKey: resp.AnchorMldsa87PublicKey,
+			V:                      protocolv2.PubkeyBundleVersion2,
+		}
+		err = protocolv2.VerifyHybridBundleV2(es384Pub, mldsa87PubBytes, bundlePayload, sigEs, sigMl)
+	default:
+		return false, fmt.Errorf("server advertised unsupported pubkey bundle version %d; upgrade revaulter-cli", version)
+	}
 	if err != nil {
 		return false, fmt.Errorf("pubkey bundle signature verification failed: %w", err)
 	}

--- a/cmd/cli/cmd/trust-store.go
+++ b/cmd/cli/cmd/trust-store.go
@@ -193,14 +193,15 @@ func verifyAndPinAnchor(server string, resp *v2PubkeyResponse, ts *trustStore, c
 		return false, fmt.Errorf("invalid pubkey bundle signature: %w", err)
 	}
 
-	// The bundle is signed once at signup and never re-signed; the advertised pubkeyBundleVersion (absent on servers that predate versioning, meaning v1) selects the canonical payload to reconstruct
+	// The bundle is signed once at signup and never re-signed
+	// The advertised pubkeyBundleVersion (absent on servers that predate versioning, i.e. v1) selects the canonical payload to reconstruct
 	version := resp.PubkeyBundleVersion
 	if version == 0 {
 		version = protocolv2.PubkeyBundleVersion1
 	}
 	switch version {
 	case protocolv2.PubkeyBundleVersion1:
-		// Legacy payload: always bound to WrappedKeyEpoch = PubkeyBundleWrappedKeyEpoch, so it is reconstructed with that constant rather than the server-reported epoch
+		// Legacy payload: always bound to WrappedKeyEpoch = 1, so it is reconstructed with that constant rather than the server-reported epoch
 		// Servers used to echo the user's live epoch in the response, which advances on password changes and would make verification fail for a signature that is still valid
 		bundlePayload := &protocolv2.PubkeyBundlePayload{
 			UserID:                 resp.UserID,
@@ -228,7 +229,7 @@ func verifyAndPinAnchor(server string, resp *v2PubkeyResponse, ts *trustStore, c
 		}
 		err = protocolv2.VerifyHybridBundleV2(es384Pub, mldsa87PubBytes, bundlePayload, sigEs, sigMl)
 	default:
-		return false, fmt.Errorf("server advertised unsupported pubkey bundle version %d; upgrade revaulter-cli", version)
+		return false, fmt.Errorf("server advertised unsupported pubkey bundle version %d - please upgrade revaulter-cli", version)
 	}
 	if err != nil {
 		return false, fmt.Errorf("pubkey bundle signature verification failed: %w", err)

--- a/cmd/cli/cmd/trust-store.go
+++ b/cmd/cli/cmd/trust-store.go
@@ -188,6 +188,8 @@ func verifyAndPinAnchor(server string, resp *v2PubkeyResponse, ts *trustStore, c
 		return false, fmt.Errorf("invalid anchorEs384PublicKey: %w", err)
 	}
 
+	// The bundle signature is always bound to WrappedKeyEpoch = PubkeyBundleWrappedKeyEpoch (it is created once at signup and never re-signed), so the payload is reconstructed with that constant rather than the server-reported epoch
+	// Servers used to echo the user's live epoch here, which advances on password changes and would make verification fail for a signature that is still valid
 	bundlePayload := &protocolv2.PubkeyBundlePayload{
 		UserID:                 resp.UserID,
 		RequestEncEcdhPubkey:   string(resp.EcdhP256),
@@ -197,7 +199,7 @@ func verifyAndPinAnchor(server string, resp *v2PubkeyResponse, ts *trustStore, c
 		AnchorEs384X:           es384JWK.X,
 		AnchorEs384Y:           es384JWK.Y,
 		AnchorMldsa87PublicKey: resp.AnchorMldsa87PublicKey,
-		WrappedKeyEpoch:        resp.WrappedKeyEpoch,
+		WrappedKeyEpoch:        protocolv2.PubkeyBundleWrappedKeyEpoch,
 	}
 	sigEs, sigMl, err := decodeHybridSignatures(resp.PubkeyBundleSignatureEs384, resp.PubkeyBundleSignatureMldsa87)
 	if err != nil {

--- a/cmd/cli/cmd/trust-store_test.go
+++ b/cmd/cli/cmd/trust-store_test.go
@@ -6,7 +6,9 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/sha512"
 	"encoding/base64"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -175,6 +177,83 @@ func TestTrustStoreFailsClosedOnNoConfirm(t *testing.T) {
 
 	_, err = ts.checkOrPinAnchor("https://example.test", "user-1", es384Pub, es384Raw, mlPubB64, mlPubBytes, nil)
 	require.Error(t, err, "first contact with nil confirmer must refuse")
+}
+
+// signTestBundle signs a pubkey-bundle payload with both anchor legs and returns base64url-encoded signatures, mirroring what the browser produces at signup
+func signTestBundle(t *testing.T, esPriv *ecdsa.PrivateKey, mlPriv *mldsa87.PrivateKey, payload *protocolv2.PubkeyBundlePayload) (sigEsB64, sigMlB64 string) {
+	t.Helper()
+
+	msg := protocolv2.CanonicalPubkeyBundleMessage(payload)
+
+	digest := sha512.Sum384(msg)
+	r, s, err := ecdsa.Sign(rand.Reader, esPriv, digest[:])
+	require.NoError(t, err)
+	sig := make([]byte, protocolv2.ES384SignatureSize)
+	const half = protocolv2.ES384SignatureSize / 2
+	rBytes := r.Bytes()
+	sBytes := s.Bytes()
+	copy(sig[half-len(rBytes):half], rBytes)
+	copy(sig[protocolv2.ES384SignatureSize-len(sBytes):], sBytes)
+
+	mlSig := make([]byte, protocolv2.MLDSA87SignatureSize)
+	err = mldsa87.SignTo(mlPriv, msg, nil, false, mlSig)
+	require.NoError(t, err)
+
+	return base64.RawURLEncoding.EncodeToString(sig), base64.RawURLEncoding.EncodeToString(mlSig)
+}
+
+// Regression test for https://github.com/ItalyPaleAle/revaulter/issues/23
+// The bundle signature is permanently bound to wrappedKeyEpoch=1 (it is created once at signup), but servers that predate the fix echo the user's live epoch in /v2/request/pubkey, which advances on password changes
+// Verification must therefore ignore the advertised epoch and reconstruct the payload with the protocol constant
+func TestVerifyAndPinAnchorIgnoresAdvertisedEpoch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "trust.json")
+
+	ts, err := loadTrustStore(path)
+	require.NoError(t, err)
+
+	esPriv, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	require.NoError(t, err)
+	jwk, err := protocolv2.ECP384PublicJWKFromECDSA(&esPriv.PublicKey)
+	require.NoError(t, err)
+	es384Body := jwk.CanonicalBody()
+
+	mlPub, mlPriv, err := mldsa87.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	mlPubBytes, err := mlPub.MarshalBinary()
+	require.NoError(t, err)
+	mlPubB64 := base64.RawURLEncoding.EncodeToString(mlPubBytes)
+
+	ecdhJSON := `{"kty":"EC","crv":"P-256","x":"xxx","y":"yyy"}`
+	mlkemB64 := base64.RawURLEncoding.EncodeToString([]byte("mlkem-pub-bytes"))
+
+	sigEs, sigMl := signTestBundle(t, esPriv, mlPriv, &protocolv2.PubkeyBundlePayload{
+		UserID:                 "user-1",
+		RequestEncEcdhPubkey:   ecdhJSON,
+		RequestEncMlkemPubkey:  mlkemB64,
+		AnchorEs384Crv:         jwk.Crv,
+		AnchorEs384Kty:         jwk.Kty,
+		AnchorEs384X:           jwk.X,
+		AnchorEs384Y:           jwk.Y,
+		AnchorMldsa87PublicKey: mlPubB64,
+		WrappedKeyEpoch:        protocolv2.PubkeyBundleWrappedKeyEpoch,
+	})
+
+	resp := &v2PubkeyResponse{
+		UserID:                 "user-1",
+		EcdhP256:               json.RawMessage(ecdhJSON),
+		Mlkem768:               mlkemB64,
+		AnchorEs384PublicKey:   es384Body,
+		AnchorMldsa87PublicKey: mlPubB64,
+		// A server that predates the fix reports the user's live epoch here — several rotations past the epoch the bundle was signed over
+		WrappedKeyEpoch:              5,
+		PubkeyBundleSignatureEs384:   sigEs,
+		PubkeyBundleSignatureMldsa87: sigMl,
+	}
+
+	pinned, err := verifyAndPinAnchor("https://example.test", resp, ts, func(string) (bool, error) { return true, nil })
+	require.NoError(t, err)
+	require.True(t, pinned)
 }
 
 func TestTrustStorePermissions(t *testing.T) {

--- a/cmd/cli/cmd/trust-store_test.go
+++ b/cmd/cli/cmd/trust-store_test.go
@@ -179,11 +179,20 @@ func TestTrustStoreFailsClosedOnNoConfirm(t *testing.T) {
 	require.Error(t, err, "first contact with nil confirmer must refuse")
 }
 
-// signTestBundle signs a pubkey-bundle payload with both anchor legs and returns base64url-encoded signatures, mirroring what the browser produces at signup
+// signTestBundle signs a legacy (v1) pubkey-bundle payload with both anchor legs and returns base64url-encoded signatures, mirroring what the browser produces at signup
 func signTestBundle(t *testing.T, esPriv *ecdsa.PrivateKey, mlPriv *mldsa87.PrivateKey, payload *protocolv2.PubkeyBundlePayload) (sigEsB64, sigMlB64 string) {
 	t.Helper()
+	return signTestBundleMessage(t, esPriv, mlPriv, protocolv2.CanonicalPubkeyBundleMessage(payload))
+}
 
-	msg := protocolv2.CanonicalPubkeyBundleMessage(payload)
+// signTestBundleV2 signs a v2 pubkey-bundle payload with both anchor legs and returns base64url-encoded signatures
+func signTestBundleV2(t *testing.T, esPriv *ecdsa.PrivateKey, mlPriv *mldsa87.PrivateKey, payload *protocolv2.PubkeyBundlePayloadV2) (sigEsB64, sigMlB64 string) {
+	t.Helper()
+	return signTestBundleMessage(t, esPriv, mlPriv, protocolv2.CanonicalPubkeyBundleMessageV2(payload))
+}
+
+func signTestBundleMessage(t *testing.T, esPriv *ecdsa.PrivateKey, mlPriv *mldsa87.PrivateKey, msg []byte) (sigEsB64, sigMlB64 string) {
+	t.Helper()
 
 	digest := sha512.Sum384(msg)
 	r, s, err := ecdsa.Sign(rand.Reader, esPriv, digest[:])
@@ -254,6 +263,76 @@ func TestVerifyAndPinAnchorIgnoresAdvertisedEpoch(t *testing.T) {
 	pinned, err := verifyAndPinAnchor("https://example.test", resp, ts, func(string) (bool, error) { return true, nil })
 	require.NoError(t, err)
 	require.True(t, pinned)
+}
+
+// TestVerifyAndPinAnchorBundleV2 covers bundles signed with the v2 payload (explicit v line, no epoch): the CLI must verify them when the server advertises pubkeyBundleVersion=2, and must refuse versions it does not know
+func TestVerifyAndPinAnchorBundleV2(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "trust.json")
+
+	esPriv, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	require.NoError(t, err)
+	jwk, err := protocolv2.ECP384PublicJWKFromECDSA(&esPriv.PublicKey)
+	require.NoError(t, err)
+	es384Body := jwk.CanonicalBody()
+
+	mlPub, mlPriv, err := mldsa87.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	mlPubBytes, err := mlPub.MarshalBinary()
+	require.NoError(t, err)
+	mlPubB64 := base64.RawURLEncoding.EncodeToString(mlPubBytes)
+
+	ecdhJSON := `{"kty":"EC","crv":"P-256","x":"xxx","y":"yyy"}`
+	mlkemB64 := base64.RawURLEncoding.EncodeToString([]byte("mlkem-pub-bytes"))
+
+	sigEs, sigMl := signTestBundleV2(t, esPriv, mlPriv, &protocolv2.PubkeyBundlePayloadV2{
+		UserID:                 "user-1",
+		RequestEncEcdhPubkey:   ecdhJSON,
+		RequestEncMlkemPubkey:  mlkemB64,
+		AnchorEs384Crv:         jwk.Crv,
+		AnchorEs384Kty:         jwk.Kty,
+		AnchorEs384X:           jwk.X,
+		AnchorEs384Y:           jwk.Y,
+		AnchorMldsa87PublicKey: mlPubB64,
+		V:                      protocolv2.PubkeyBundleVersion2,
+	})
+
+	newResp := func(version int64) *v2PubkeyResponse {
+		return &v2PubkeyResponse{
+			UserID:                 "user-1",
+			EcdhP256:               json.RawMessage(ecdhJSON),
+			Mlkem768:               mlkemB64,
+			AnchorEs384PublicKey:   es384Body,
+			AnchorMldsa87PublicKey: mlPubB64,
+			// v2 responses still carry a wrappedKeyEpoch field for older CLIs; its value must be irrelevant here
+			WrappedKeyEpoch:              1,
+			PubkeyBundleVersion:          version,
+			PubkeyBundleSignatureEs384:   sigEs,
+			PubkeyBundleSignatureMldsa87: sigMl,
+		}
+	}
+
+	t.Run("verifies and pins a v2 bundle", func(t *testing.T) {
+		ts, tsErr := loadTrustStore(path)
+		require.NoError(t, tsErr)
+		pinned, vErr := verifyAndPinAnchor("https://example.test", newResp(2), ts, func(string) (bool, error) { return true, nil })
+		require.NoError(t, vErr)
+		require.True(t, pinned)
+	})
+
+	t.Run("v2 signature advertised as v1 fails closed", func(t *testing.T) {
+		ts, tsErr := loadTrustStore(path)
+		require.NoError(t, tsErr)
+		_, vErr := verifyAndPinAnchor("https://example.test", newResp(0), ts, func(string) (bool, error) { return true, nil })
+		require.ErrorContains(t, vErr, "signature verification failed")
+	})
+
+	t.Run("unknown version fails closed", func(t *testing.T) {
+		ts, tsErr := loadTrustStore(path)
+		require.NoError(t, tsErr)
+		_, vErr := verifyAndPinAnchor("https://example.test", newResp(3), ts, func(string) (bool, error) { return true, nil })
+		require.ErrorContains(t, vErr, "unsupported pubkey bundle version")
+	})
 }
 
 func TestTrustStorePermissions(t *testing.T) {

--- a/cmd/cli/cmd/trust-store_test.go
+++ b/cmd/cli/cmd/trust-store_test.go
@@ -182,12 +182,14 @@ func TestTrustStoreFailsClosedOnNoConfirm(t *testing.T) {
 // signTestBundle signs a legacy (v1) pubkey-bundle payload with both anchor legs and returns base64url-encoded signatures, mirroring what the browser produces at signup
 func signTestBundle(t *testing.T, esPriv *ecdsa.PrivateKey, mlPriv *mldsa87.PrivateKey, payload *protocolv2.PubkeyBundlePayload) (sigEsB64, sigMlB64 string) {
 	t.Helper()
+
 	return signTestBundleMessage(t, esPriv, mlPriv, protocolv2.CanonicalPubkeyBundleMessage(payload))
 }
 
 // signTestBundleV2 signs a v2 pubkey-bundle payload with both anchor legs and returns base64url-encoded signatures
 func signTestBundleV2(t *testing.T, esPriv *ecdsa.PrivateKey, mlPriv *mldsa87.PrivateKey, payload *protocolv2.PubkeyBundlePayloadV2) (sigEsB64, sigMlB64 string) {
 	t.Helper()
+
 	return signTestBundleMessage(t, esPriv, mlPriv, protocolv2.CanonicalPubkeyBundleMessageV2(payload))
 }
 
@@ -211,10 +213,11 @@ func signTestBundleMessage(t *testing.T, esPriv *ecdsa.PrivateKey, mlPriv *mldsa
 	return base64.RawURLEncoding.EncodeToString(sig), base64.RawURLEncoding.EncodeToString(mlSig)
 }
 
-// Regression test for https://github.com/ItalyPaleAle/revaulter/issues/23
-// The bundle signature is permanently bound to wrappedKeyEpoch=1 (it is created once at signup), but servers that predate the fix echo the user's live epoch in /v2/request/pubkey, which advances on password changes
-// Verification must therefore ignore the advertised epoch and reconstruct the payload with the protocol constant
 func TestVerifyAndPinAnchorIgnoresAdvertisedEpoch(t *testing.T) {
+	// Regression test for https://github.com/ItalyPaleAle/revaulter/issues/23
+	// The bundle signature is permanently bound to wrappedKeyEpoch=1 (it is created once at signup), but servers that predate the fix echo the user's live epoch in /v2/request/pubkey, which advances on password changes
+	// Verification must therefore ignore the advertised epoch and reconstruct the payload with the protocol constant
+
 	dir := t.TempDir()
 	path := filepath.Join(dir, "trust.json")
 
@@ -248,14 +251,13 @@ func TestVerifyAndPinAnchorIgnoresAdvertisedEpoch(t *testing.T) {
 		WrappedKeyEpoch:        protocolv2.PubkeyBundleWrappedKeyEpoch,
 	})
 
+	// A server that predates the fix reports the user's live epoch in WrappedKeyEpoch, but this field is ignored
 	resp := &v2PubkeyResponse{
-		UserID:                 "user-1",
-		EcdhP256:               json.RawMessage(ecdhJSON),
-		Mlkem768:               mlkemB64,
-		AnchorEs384PublicKey:   es384Body,
-		AnchorMldsa87PublicKey: mlPubB64,
-		// A server that predates the fix reports the user's live epoch here — several rotations past the epoch the bundle was signed over
-		WrappedKeyEpoch:              5,
+		UserID:                       "user-1",
+		EcdhP256:                     json.RawMessage(ecdhJSON),
+		Mlkem768:                     mlkemB64,
+		AnchorEs384PublicKey:         es384Body,
+		AnchorMldsa87PublicKey:       mlPubB64,
 		PubkeyBundleSignatureEs384:   sigEs,
 		PubkeyBundleSignatureMldsa87: sigMl,
 	}
@@ -265,7 +267,6 @@ func TestVerifyAndPinAnchorIgnoresAdvertisedEpoch(t *testing.T) {
 	require.True(t, pinned)
 }
 
-// TestVerifyAndPinAnchorBundleV2 covers bundles signed with the v2 payload (explicit v line, no epoch): the CLI must verify them when the server advertises pubkeyBundleVersion=2, and must refuse versions it does not know
 func TestVerifyAndPinAnchorBundleV2(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "trust.json")
@@ -299,13 +300,11 @@ func TestVerifyAndPinAnchorBundleV2(t *testing.T) {
 
 	newResp := func(version int64) *v2PubkeyResponse {
 		return &v2PubkeyResponse{
-			UserID:                 "user-1",
-			EcdhP256:               json.RawMessage(ecdhJSON),
-			Mlkem768:               mlkemB64,
-			AnchorEs384PublicKey:   es384Body,
-			AnchorMldsa87PublicKey: mlPubB64,
-			// v2 responses still carry a wrappedKeyEpoch field for older CLIs; its value must be irrelevant here
-			WrappedKeyEpoch:              1,
+			UserID:                       "user-1",
+			EcdhP256:                     json.RawMessage(ecdhJSON),
+			Mlkem768:                     mlkemB64,
+			AnchorEs384PublicKey:         es384Body,
+			AnchorMldsa87PublicKey:       mlPubB64,
 			PubkeyBundleVersion:          version,
 			PubkeyBundleSignatureEs384:   sigEs,
 			PubkeyBundleSignatureMldsa87: sigMl,

--- a/docs/content/advanced/rest-api-reference.md
+++ b/docs/content/advanced/rest-api-reference.md
@@ -151,12 +151,15 @@ Get the user's static public encryption keys, along with the hybrid anchor publi
   "anchorEs384PublicKey": "<canonical JWK body>",
   "anchorMldsa87PublicKey": "<base64url>",
   "wrappedKeyEpoch": 1,
+  "pubkeyBundleVersion": 2,
   "pubkeyBundleSignatureEs384": "<base64url>",
   "pubkeyBundleSignatureMldsa87": "<base64url>"
 }
 ```
 
-`wrappedKeyEpoch` is the epoch bound into the pubkey bundle signatures. The bundle is signed once at signup (always at epoch `1`) and is never re-signed, so this value does not track the user's live wrapped-key epoch, which advances on password changes.
+`pubkeyBundleVersion` tells the verifier which canonical payload the bundle signatures cover: `1` (legacy; the payload binds `wrappedKeyEpoch`) or `2` (the payload binds an explicit `v` line). The bundle is signed once at signup and is never re-signed.
+
+`wrappedKeyEpoch` is retained for older CLIs that verify version-1 bundles: it is the epoch bound into v1 signatures, which is always `1`. It does not track the user's live wrapped-key epoch, which advances on password changes.
 
 Returns `412 Precondition Failed` if the user has not completed signup (no encryption keys configured).
 
@@ -505,9 +508,20 @@ Upload the user's wrapped primary key and static public encryption keys after re
     "y": "<base64url>"
   },
   "requestEncMlkemPubkey": "<base64url>",
-  "wrappedPrimaryKey": "<base64url>"
+  "wrappedPrimaryKey": "<base64url>",
+  "anchorEs384PublicKey": "<canonical JWK body>",
+  "anchorMldsa87PublicKey": "<base64url>",
+  "pubkeyBundleSignatureEs384": "<base64url>",
+  "pubkeyBundleSignatureMldsa87": "<base64url>",
+  "pubkeyBundleVersion": 2,
+  "wrappedAnchorKey": "<base64url>",
+  "attestationPayload": "<canonical body>",
+  "attestationSignatureEs384": "<base64url>",
+  "attestationSignatureMldsa87": "<base64url>"
 }
 ```
+
+`pubkeyBundleVersion` selects the canonical payload the bundle signatures cover: `1` (legacy; binds `wrappedKeyEpoch`, which is always `1` at signup) or `2` (binds an explicit `v` line instead). When omitted, `1` is assumed for compatibility with older clients; current clients always sign version `2`.
 
 **Response:** `200 OK`
 

--- a/docs/content/advanced/rest-api-reference.md
+++ b/docs/content/advanced/rest-api-reference.md
@@ -134,21 +134,29 @@ The shape varies per operation. All `value`/`nonce`/`tag`/`additionalData` field
 
 ### `GET /v2/request/pubkey`
 
-Get the user's static public encryption keys. The CLI uses these to encrypt request payloads end-to-end.
+Get the user's static public encryption keys, along with the hybrid anchor public keys and the pubkey bundle signatures. The CLI uses the encryption keys to encrypt request payloads end-to-end, pins the anchor keys (TOFU), and verifies both bundle signatures to detect server-side pubkey substitution.
 
 **Response:** `200 OK`
 
 ```json
 {
+  "userId": "<uuid>",
   "ecdhP256": {
     "kty": "EC",
     "crv": "P-256",
     "x": "<base64url>",
     "y": "<base64url>"
   },
-  "mlkem768": "<base64url>"
+  "mlkem768": "<base64url>",
+  "anchorEs384PublicKey": "<canonical JWK body>",
+  "anchorMldsa87PublicKey": "<base64url>",
+  "wrappedKeyEpoch": 1,
+  "pubkeyBundleSignatureEs384": "<base64url>",
+  "pubkeyBundleSignatureMldsa87": "<base64url>"
 }
 ```
+
+`wrappedKeyEpoch` is the epoch bound into the pubkey bundle signatures. The bundle is signed once at signup (always at epoch `1`) and is never re-signed, so this value does not track the user's live wrapped-key epoch, which advances on password changes.
 
 Returns `412 Precondition Failed` if the user has not completed signup (no encryption keys configured).
 

--- a/docs/content/advanced/rest-api-reference.md
+++ b/docs/content/advanced/rest-api-reference.md
@@ -157,7 +157,7 @@ Get the user's static public encryption keys, along with the hybrid anchor publi
 }
 ```
 
-`pubkeyBundleVersion` tells the verifier which canonical payload the bundle signatures cover: `1` (legacy; the payload binds `wrappedKeyEpoch`) or `2` (the payload binds an explicit `v` line). The bundle is signed once at signup and is never re-signed.
+`pubkeyBundleVersion` tells the verifier which canonical payload the bundle signatures cover: `1` (legacy, the payload binds `wrappedKeyEpoch`) or `2` (the payload binds an explicit `v` line). The bundle is signed once at signup and is never re-signed.
 
 `wrappedKeyEpoch` is retained for older CLIs that verify version-1 bundles: it is the epoch bound into v1 signatures, which is always `1`. It does not track the user's live wrapped-key epoch, which advances on password changes.
 
@@ -521,7 +521,7 @@ Upload the user's wrapped primary key and static public encryption keys after re
 }
 ```
 
-`pubkeyBundleVersion` selects the canonical payload the bundle signatures cover: `1` (legacy; binds `wrappedKeyEpoch`, which is always `1` at signup) or `2` (binds an explicit `v` line instead). When omitted, `1` is assumed for compatibility with older clients; current clients always sign version `2`.
+`pubkeyBundleVersion` selects the canonical payload the bundle signatures cover: `1` (legacy - binds `wrappedKeyEpoch`, which is always `1` at signup) or `2` (binds an explicit `v` line instead). Current clients always sign version `2`. When omitted, `1` is assumed for compatibility with older clients.
 
 **Response:** `200 OK`
 

--- a/docs/content/examples/signing-a-release-binary-from-github-actions.md
+++ b/docs/content/examples/signing-a-release-binary-from-github-actions.md
@@ -25,7 +25,7 @@ jobs:
   build-and-sign:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with: { go-version: '1.26' }
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/italypaleale/revaulter
 
 go 1.26.4
 
+tool github.com/fchimpan/gomod-age
+
 require (
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cloudflare/circl v1.6.4
@@ -59,6 +61,7 @@ require (
 	github.com/digitorus/pkcs7 v0.0.0-20230818184609-3a137a874352 // indirect
 	github.com/digitorus/timestamp v0.0.0-20231217203849-220c5c2851b7 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/fchimpan/gomod-age v0.1.1-0.20260405015303-09005169a479 // indirect
 	github.com/felixge/httpsnoop v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,8 @@ github.com/digitorus/timestamp v0.0.0-20231217203849-220c5c2851b7 h1:lxmTCgmHE1G
 github.com/digitorus/timestamp v0.0.0-20231217203849-220c5c2851b7/go.mod h1:GvWntX9qiTlOud0WkQ6ewFm0LPy5JUR1Xo0Ngbd1w6Y=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/fchimpan/gomod-age v0.1.1-0.20260405015303-09005169a479 h1:DIiy+URimdWW0YcMOMylyD2nsRUV6SxvCoPdKh5PCb4=
+github.com/fchimpan/gomod-age v0.1.1-0.20260405015303-09005169a479/go.mod h1:3kypUxKFWfX23KnOg6M9pQiiCfb4jeUjm6rfGM4/7Wo=
 github.com/felixge/httpsnoop v1.1.0 h1:3YtUj32ZZkqZtt3sZZsClsymw/QDuVfpNhoA31zeORc=
 github.com/felixge/httpsnoop v1.1.0/go.mod h1:Zqxgdd+1Rkcz8euOqdr7lqgCRJztwr5hp9vDSi5UZCE=
 github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=

--- a/pkg/db/auth.go
+++ b/pkg/db/auth.go
@@ -52,9 +52,11 @@ type User struct {
 	AnchorMldsa87PublicKey       string
 	PubkeyBundleSignatureEs384   string
 	PubkeyBundleSignatureMldsa87 string
-	WrappedKeyEpoch              int64
-	AllowedIPs                   []string
-	Ready                        bool
+	// PubkeyBundleVersion is the version of the canonical payload the stored bundle signatures cover: 1 (legacy, binds wrappedKeyEpoch) or 2 (binds an explicit v line)
+	PubkeyBundleVersion int64
+	WrappedKeyEpoch     int64
+	AllowedIPs          []string
+	Ready               bool
 }
 
 type AuthChallenge struct {
@@ -122,9 +124,11 @@ type FinalizeSignupInput struct {
 	AnchorMldsa87PublicKey       string
 	PubkeyBundleSignatureEs384   string
 	PubkeyBundleSignatureMldsa87 string
-	AttestationPayload           string
-	AttestationSignatureEs384    string
-	AttestationSignatureMldsa87  string
+	// PubkeyBundleVersion is the payload version the bundle signatures cover; the caller (which verified the signatures) must set it to 1 or 2
+	PubkeyBundleVersion         int64
+	AttestationPayload          string
+	AttestationSignatureEs384   string
+	AttestationSignatureMldsa87 string
 }
 
 var (
@@ -184,12 +188,12 @@ func (s *AuthStore) getUser(ctx context.Context, column string, value string) (*
 		user          User
 		allowedIPsCSV string
 	)
-	query := `SELECT id, display_name, status, webauthn_user_id, request_key, request_enc_ecdh_pubkey, request_enc_mlkem_pubkey, anchor_es384_public_key, anchor_mldsa87_public_key, pubkey_bundle_signature_es384, pubkey_bundle_signature_mldsa87, wrapped_key_epoch, allowed_ips, ready
+	query := `SELECT id, display_name, status, webauthn_user_id, request_key, request_enc_ecdh_pubkey, request_enc_mlkem_pubkey, anchor_es384_public_key, anchor_mldsa87_public_key, pubkey_bundle_signature_es384, pubkey_bundle_signature_mldsa87, pubkey_bundle_version, wrapped_key_epoch, allowed_ips, ready
 		FROM v2_users
 		WHERE ` + column + ` = $1`
 	err := s.db.
 		QueryRow(ctx, query, value).
-		Scan(&user.ID, &user.DisplayName, &user.Status, &user.WebAuthnUserID, &user.RequestKey, &user.RequestEncEcdhPubkey, &user.RequestEncMlkemPubkey, &user.AnchorEs384PublicKey, &user.AnchorMldsa87PublicKey, &user.PubkeyBundleSignatureEs384, &user.PubkeyBundleSignatureMldsa87, &user.WrappedKeyEpoch, &allowedIPsCSV, &user.Ready)
+		Scan(&user.ID, &user.DisplayName, &user.Status, &user.WebAuthnUserID, &user.RequestKey, &user.RequestEncEcdhPubkey, &user.RequestEncMlkemPubkey, &user.AnchorEs384PublicKey, &user.AnchorMldsa87PublicKey, &user.PubkeyBundleSignatureEs384, &user.PubkeyBundleSignatureMldsa87, &user.PubkeyBundleVersion, &user.WrappedKeyEpoch, &allowedIPsCSV, &user.Ready)
 	if s.db.IsNoRowsError(err) {
 		return nil, nil
 	} else if err != nil {
@@ -414,6 +418,12 @@ func (s *AuthStore) FinalizeSignup(ctx context.Context, in FinalizeSignupInput) 
 		panic("FinalizeSignup must be invoked in a transaction")
 	}
 
+	// Default to the legacy payload version when the caller did not set one explicitly
+	bundleVersion := in.PubkeyBundleVersion
+	if bundleVersion == 0 {
+		bundleVersion = 1
+	}
+
 	now := time.Now().Unix()
 	updatedUser := &User{}
 	var allowedIPsCSV string
@@ -426,15 +436,16 @@ func (s *AuthStore) FinalizeSignup(ctx context.Context, in FinalizeSignupInput) 
 				anchor_mldsa87_public_key = $4,
 				pubkey_bundle_signature_es384 = $5,
 				pubkey_bundle_signature_mldsa87 = $6,
+				pubkey_bundle_version = $7,
 				ready = true,
-				updated_at = $7
-			WHERE id = $8 AND ready = false
+				updated_at = $8
+			WHERE id = $9 AND ready = false
 			RETURNING
-				id, display_name, status, webauthn_user_id, request_key, request_enc_ecdh_pubkey, request_enc_mlkem_pubkey, anchor_es384_public_key, anchor_mldsa87_public_key, pubkey_bundle_signature_es384, pubkey_bundle_signature_mldsa87, wrapped_key_epoch, allowed_ips, ready`,
+				id, display_name, status, webauthn_user_id, request_key, request_enc_ecdh_pubkey, request_enc_mlkem_pubkey, anchor_es384_public_key, anchor_mldsa87_public_key, pubkey_bundle_signature_es384, pubkey_bundle_signature_mldsa87, pubkey_bundle_version, wrapped_key_epoch, allowed_ips, ready`,
 			in.RequestEncEcdhPubkey, in.RequestEncMlkemPubkey,
 			in.AnchorEs384PublicKey, in.AnchorMldsa87PublicKey,
 			in.PubkeyBundleSignatureEs384, in.PubkeyBundleSignatureMldsa87,
-			now, in.UserID,
+			bundleVersion, now, in.UserID,
 		).
 		Scan(
 			&updatedUser.ID,
@@ -448,6 +459,7 @@ func (s *AuthStore) FinalizeSignup(ctx context.Context, in FinalizeSignupInput) 
 			&updatedUser.AnchorMldsa87PublicKey,
 			&updatedUser.PubkeyBundleSignatureEs384,
 			&updatedUser.PubkeyBundleSignatureMldsa87,
+			&updatedUser.PubkeyBundleVersion,
 			&updatedUser.WrappedKeyEpoch,
 			&allowedIPsCSV,
 			&updatedUser.Ready,

--- a/pkg/db/auth.go
+++ b/pkg/db/auth.go
@@ -52,11 +52,10 @@ type User struct {
 	AnchorMldsa87PublicKey       string
 	PubkeyBundleSignatureEs384   string
 	PubkeyBundleSignatureMldsa87 string
-	// PubkeyBundleVersion is the version of the canonical payload the stored bundle signatures cover: 1 (legacy, binds wrappedKeyEpoch) or 2 (binds an explicit v line)
-	PubkeyBundleVersion int64
-	WrappedKeyEpoch     int64
-	AllowedIPs          []string
-	Ready               bool
+	PubkeyBundleVersion          int64
+	WrappedKeyEpoch              int64
+	AllowedIPs                   []string
+	Ready                        bool
 }
 
 type AuthChallenge struct {
@@ -124,11 +123,10 @@ type FinalizeSignupInput struct {
 	AnchorMldsa87PublicKey       string
 	PubkeyBundleSignatureEs384   string
 	PubkeyBundleSignatureMldsa87 string
-	// PubkeyBundleVersion is the payload version the bundle signatures cover; the caller (which verified the signatures) must set it to 1 or 2
-	PubkeyBundleVersion         int64
-	AttestationPayload          string
-	AttestationSignatureEs384   string
-	AttestationSignatureMldsa87 string
+	PubkeyBundleVersion          int64
+	AttestationPayload           string
+	AttestationSignatureEs384    string
+	AttestationSignatureMldsa87  string
 }
 
 var (
@@ -418,12 +416,6 @@ func (s *AuthStore) FinalizeSignup(ctx context.Context, in FinalizeSignupInput) 
 		panic("FinalizeSignup must be invoked in a transaction")
 	}
 
-	// Default to the legacy payload version when the caller did not set one explicitly
-	bundleVersion := in.PubkeyBundleVersion
-	if bundleVersion == 0 {
-		bundleVersion = 1
-	}
-
 	now := time.Now().Unix()
 	updatedUser := &User{}
 	var allowedIPsCSV string
@@ -445,7 +437,7 @@ func (s *AuthStore) FinalizeSignup(ctx context.Context, in FinalizeSignupInput) 
 			in.RequestEncEcdhPubkey, in.RequestEncMlkemPubkey,
 			in.AnchorEs384PublicKey, in.AnchorMldsa87PublicKey,
 			in.PubkeyBundleSignatureEs384, in.PubkeyBundleSignatureMldsa87,
-			bundleVersion, now, in.UserID,
+			in.PubkeyBundleVersion, now, in.UserID,
 		).
 		Scan(
 			&updatedUser.ID,

--- a/pkg/db/auth_test.go
+++ b/pkg/db/auth_test.go
@@ -113,6 +113,7 @@ func TestAuthStorePasswordCanaryAndAllowedIPs(t *testing.T) {
 				WrappedPrimaryKey:     "canary-1",
 				RequestEncEcdhPubkey:  `{"kty":"EC","crv":"P-256","x":"test","y":"test"}`,
 				RequestEncMlkemPubkey: "dGVzdC1tbGtlbS1wdWJrZXk",
+				PubkeyBundleVersion:   2,
 			})
 			require.NoError(t, err)
 
@@ -121,6 +122,7 @@ func TestAuthStorePasswordCanaryAndAllowedIPs(t *testing.T) {
 				WrappedPrimaryKey:     "canary-2",
 				RequestEncEcdhPubkey:  `{"kty":"EC"}`,
 				RequestEncMlkemPubkey: "dGVzdA",
+				PubkeyBundleVersion:   2,
 			})
 			require.ErrorIs(t, err, ErrAlreadyFinalized)
 
@@ -165,6 +167,7 @@ func TestAuthStoreRegenerateRequestKey(t *testing.T) {
 				UserID:                "user-1",
 				RequestEncEcdhPubkey:  `{"kty":"EC"}`,
 				RequestEncMlkemPubkey: "mlkem-pub",
+				PubkeyBundleVersion:   2,
 			})
 			require.NoError(t, err)
 
@@ -477,6 +480,7 @@ func TestAuthStoreDeleteNonreadyUser(t *testing.T) {
 				WrappedPrimaryKey:     "canary-ready",
 				RequestEncEcdhPubkey:  `{"kty":"EC"}`,
 				RequestEncMlkemPubkey: "mlkem-ready",
+				PubkeyBundleVersion:   2,
 			})
 			require.NoError(t, err)
 
@@ -531,6 +535,7 @@ func TestAuthStoreUpdateDisplayName(t *testing.T) {
 				UserID:                "user-1",
 				RequestEncEcdhPubkey:  `{"kty":"EC"}`,
 				RequestEncMlkemPubkey: "mlkem-pub",
+				PubkeyBundleVersion:   2,
 			})
 			require.NoError(t, err)
 
@@ -584,6 +589,7 @@ func TestAuthStoreUpdateCredentialWrappedKey(t *testing.T) {
 				WrappedPrimaryKey:     "initial-key",
 				RequestEncEcdhPubkey:  `{"kty":"EC"}`,
 				RequestEncMlkemPubkey: "mlkem-pub",
+				PubkeyBundleVersion:   2,
 			})
 			require.NoError(t, err)
 
@@ -649,6 +655,7 @@ func TestAuthStoreCredentialWrappedKeyEpochRotation(t *testing.T) {
 				WrappedPrimaryKey:     "wrapped-1-v1",
 				RequestEncEcdhPubkey:  `{"kty":"EC"}`,
 				RequestEncMlkemPubkey: "mlkem-pub",
+				PubkeyBundleVersion:   2,
 			})
 			require.NoError(t, err)
 

--- a/pkg/db/backup/backup_test.go
+++ b/pkg/db/backup/backup_test.go
@@ -53,15 +53,15 @@ func canonicalFixture() fixtureBackup {
 	const ts = int64(1700000000)
 
 	return fixtureBackup{
-		SchemaLevel: 1,
+		SchemaLevel: 2,
 		Tables: []fixtureTable{
 			tableFixture("v2_audit_events", [][]any{
 				{fxAuditID1, ts, "auth.login.finish", "success", "session", fxUserAID, fxUserAID, nil, nil, fxRequestID, "http-1", "127.0.0.1", "ua/1.0", `{"flow":"webauthn"}`},
 				{fxAuditID2, ts + 1, "auth.logout", "success", "session", fxUserBID, nil, nil, nil, nil, nil, nil, nil, `{}`},
 			}),
 			tableFixture("v2_users", [][]any{
-				{fxUserAID, "Alice", "active", "wa-A", "rk-A", "ecdh-A", "mlkem-A", "es384-A", "mldsa-A", "sig-es-A", "sig-mldsa-A", int64(1), "10.0.0.0/8", true, ts, ts},
-				{fxUserBID, "Bob", "active", "wa-B", "rk-B", "", "", "", "", "", "", int64(2), "", false, ts - 100, ts - 50},
+				{fxUserAID, "Alice", "active", "wa-A", "rk-A", "ecdh-A", "mlkem-A", "es384-A", "mldsa-A", "sig-es-A", "sig-mldsa-A", int64(1), "10.0.0.0/8", true, ts, ts, int64(1)},
+				{fxUserBID, "Bob", "active", "wa-B", "rk-B", "", "", "", "", "", "", int64(2), "", false, ts - 100, ts - 50, int64(2)},
 			}),
 			tableFixture("v2_published_signing_keys", [][]any{
 				{fxSigningID, fxUserAID, "ES384", "label-1", `{"jwk":1}`, "PEMDATA", true, "pub-payload", "pub-sig-es", "pub-sig-mldsa", ts, ts},

--- a/pkg/db/backup/tables_gen.go
+++ b/pkg/db/backup/tables_gen.go
@@ -43,6 +43,7 @@ var backupTables = []tableSpec{
 			{name: "ready", kind: colKindBool},
 			{name: "created_at", kind: colKindText},
 			{name: "updated_at", kind: colKindText},
+			{name: "pubkey_bundle_version", kind: colKindText},
 		},
 	},
 	{

--- a/pkg/db/migrations/postgres/0002_pubkey_bundle_version.sql
+++ b/pkg/db/migrations/postgres/0002_pubkey_bundle_version.sql
@@ -1,0 +1,4 @@
+-- Version of the pubkey bundle signature stored on the user row
+-- 1 = legacy payload that binds wrappedKeyEpoch (always signed as 1 at signup); 2 = payload that binds an explicit `v` line instead
+-- Existing rows were all signed with the legacy payload, hence the default
+ALTER TABLE v2_users ADD COLUMN pubkey_bundle_version bigint NOT NULL DEFAULT 1;

--- a/pkg/db/migrations/postgres/0002_pubkey_bundle_version.sql
+++ b/pkg/db/migrations/postgres/0002_pubkey_bundle_version.sql
@@ -1,4 +1,5 @@
 -- Version of the pubkey bundle signature stored on the user row
--- 1 = legacy payload that binds wrappedKeyEpoch (always signed as 1 at signup); 2 = payload that binds an explicit `v` line instead
--- Existing rows were all signed with the legacy payload, hence the default
+-- 1 = legacy payload that binds wrappedKeyEpoch (always signed as 1 at signup)
+-- 2 = payload that binds an explicit `v` line instead
+-- Setting default to 1 because existing rows were all signed with the legacy payload
 ALTER TABLE v2_users ADD COLUMN pubkey_bundle_version bigint NOT NULL DEFAULT 1;

--- a/pkg/db/migrations/sqlite/0002_pubkey_bundle_version.sql
+++ b/pkg/db/migrations/sqlite/0002_pubkey_bundle_version.sql
@@ -1,0 +1,4 @@
+-- Version of the pubkey bundle signature stored on the user row
+-- 1 = legacy payload that binds wrappedKeyEpoch (always signed as 1 at signup); 2 = payload that binds an explicit `v` line instead
+-- Existing rows were all signed with the legacy payload, hence the default
+ALTER TABLE v2_users ADD COLUMN pubkey_bundle_version INTEGER NOT NULL DEFAULT 1;

--- a/pkg/db/migrations/sqlite/0002_pubkey_bundle_version.sql
+++ b/pkg/db/migrations/sqlite/0002_pubkey_bundle_version.sql
@@ -1,4 +1,5 @@
 -- Version of the pubkey bundle signature stored on the user row
--- 1 = legacy payload that binds wrappedKeyEpoch (always signed as 1 at signup); 2 = payload that binds an explicit `v` line instead
--- Existing rows were all signed with the legacy payload, hence the default
+-- 1 = legacy payload that binds wrappedKeyEpoch (always signed as 1 at signup)
+-- 2 = payload that binds an explicit `v` line instead
+-- Setting default to 1 because existing rows were all signed with the legacy payload
 ALTER TABLE v2_users ADD COLUMN pubkey_bundle_version INTEGER NOT NULL DEFAULT 1;

--- a/pkg/protocolv2/anchor.go
+++ b/pkg/protocolv2/anchor.go
@@ -26,6 +26,11 @@ const (
 	WrappedAnchorAADFmt = "revaulter/v2/wrapped-anchor\nuserId=%s\nv=1"
 )
 
+// PubkeyBundleWrappedKeyEpoch is the wrappedKeyEpoch value bound into every pubkey bundle signature
+// The bundle is hybrid-signed exactly once, in the browser at signup, when the user's epoch is always 1; the anchor and request-encryption pubkeys it covers are immutable afterwards, so the signature is never regenerated
+// The user's live wrapped-key epoch advances on password changes (it tracks re-wraps of the primary key, not the bundle), so verifiers must reconstruct the signed payload with this constant, NOT the user's current epoch
+const PubkeyBundleWrappedKeyEpoch int64 = 1
+
 // Fixed sizes for the PQ and classical legs of the hybrid anchor
 const (
 	MLDSA87PublicKeySize = mldsa87.PublicKeySize // 2592

--- a/pkg/protocolv2/anchor.go
+++ b/pkg/protocolv2/anchor.go
@@ -26,10 +26,17 @@ const (
 	WrappedAnchorAADFmt = "revaulter/v2/wrapped-anchor\nuserId=%s\nv=1"
 )
 
-// PubkeyBundleWrappedKeyEpoch is the wrappedKeyEpoch value bound into every pubkey bundle signature
-// The bundle is hybrid-signed exactly once, in the browser at signup, when the user's epoch is always 1; the anchor and request-encryption pubkeys it covers are immutable afterwards, so the signature is never regenerated
-// The user's live wrapped-key epoch advances on password changes (it tracks re-wraps of the primary key, not the bundle), so verifiers must reconstruct the signed payload with this constant, NOT the user's current epoch
-const PubkeyBundleWrappedKeyEpoch int64 = 1
+// Pubkey bundle signature versions
+// The bundle is hybrid-signed exactly once, in the browser at signup; the anchor and request-encryption pubkeys it covers are immutable afterwards, so the signature is never regenerated
+// Version 1 (legacy) bound the user's wrapped-key epoch into the signed payload, which was always 1 at signup; the live epoch advances on password changes (it tracks re-wraps of the primary key, not the bundle), so verifiers of v1 bundles must reconstruct the payload with PubkeyBundleWrappedKeyEpoch, NOT the user's current epoch
+// Version 2 drops the epoch entirely and instead binds an explicit `v` line, so the signed bytes carry an authenticated format version
+const (
+	PubkeyBundleVersion1 int64 = 1
+	PubkeyBundleVersion2 int64 = 2
+
+	// PubkeyBundleWrappedKeyEpoch is the wrappedKeyEpoch value bound into every v1 pubkey bundle signature
+	PubkeyBundleWrappedKeyEpoch int64 = 1
+)
 
 // Fixed sizes for the PQ and classical legs of the hybrid anchor
 const (
@@ -157,6 +164,39 @@ func ParsePubkeyBundlePayload(body string) (PubkeyBundlePayload, error) {
 	return p, nil
 }
 
+// PubkeyBundlePayloadV2 is the version-2 canonicalized pubkey-bundle payload
+// It replaces the legacy wrappedKeyEpoch line (which carried no verifiable meaning — the bundle is signed once at signup and the epoch tracks unrelated key re-wraps) with an explicit `v` line, so the signed bytes carry an authenticated format version
+// The order is load-bearing: client and server must produce identical bytes; `v` is last, matching SigningKeyPublicationPayload
+type PubkeyBundlePayloadV2 struct {
+	UserID                 string `key:"userId"`
+	RequestEncEcdhPubkey   string `key:"requestEncEcdhPubkey"`
+	RequestEncMlkemPubkey  string `key:"requestEncMlkemPubkey"`
+	AnchorEs384Crv         string `key:"anchorEs384Crv"`
+	AnchorEs384Kty         string `key:"anchorEs384Kty"`
+	AnchorEs384X           string `key:"anchorEs384X"`
+	AnchorEs384Y           string `key:"anchorEs384Y"`
+	AnchorMldsa87PublicKey string `key:"anchorMldsa87PublicKey"`
+	V                      int64  `key:"v"`
+}
+
+// CanonicalBody encodes the v2 pubkey-bundle payload as ordered key=value lines separated by '\n', with no trailing newline
+// This is the body that (with the domain-separation prefix) is signed by both anchor legs
+func (p PubkeyBundlePayloadV2) CanonicalBody() string {
+	return canonicalBodyFromTaggedFields(p)
+}
+
+// ParsePubkeyBundlePayloadV2 parses a canonical body string back into a PubkeyBundlePayloadV2
+// The input must list every expected key in the documented order, exactly once, separated by '\n', with no trailing newline
+func ParsePubkeyBundlePayloadV2(body string) (PubkeyBundlePayloadV2, error) {
+	var p PubkeyBundlePayloadV2
+	err := parseTaggedFields(body, &p)
+	if err != nil {
+		return p, err
+	}
+
+	return p, nil
+}
+
 func parseTaggedFields(body string, out any) error {
 	v := reflect.ValueOf(out)
 	if v.Kind() != reflect.Pointer || v.Elem().Kind() != reflect.Struct {
@@ -221,6 +261,16 @@ func CanonicalPubkeyBundleMessage(payload *PubkeyBundlePayload) []byte {
 	return out
 }
 
+// CanonicalPubkeyBundleMessageV2 returns the domain-separated, canonically-encoded v2 bundle message signed by both anchor legs
+// The domain-separation prefix is shared with v1: the two formats cannot be confused because the canonical bodies differ (v1 ends with a wrappedKeyEpoch line, v2 with a v line) and parsing is strict about keys and order
+func CanonicalPubkeyBundleMessageV2(payload *PubkeyBundlePayloadV2) []byte {
+	body := payload.CanonicalBody()
+	out := make([]byte, len(PubkeyBundlePrefix)+len(body))
+	copy(out[0:len(PubkeyBundlePrefix)], PubkeyBundlePrefix)
+	copy(out[len(PubkeyBundlePrefix):], body)
+	return out
+}
+
 // VerifyHybridAttestation verifies that both legs of the hybrid signature cover the canonical attestation message
 // Both must validate; if either fails the call returns an error describing which legs rejected the signature
 //
@@ -241,6 +291,16 @@ func VerifyHybridAttestation(es384Pub *ecdsa.PublicKey, mldsa87PubBytes []byte, 
 // Callers MUST independently bind the anchor pubkeys to the principal they represent (e.g., by pinning them at registration and comparing on subsequent use) before trusting the payload.
 func VerifyHybridBundle(es384Pub *ecdsa.PublicKey, mldsa87PubBytes []byte, payload *PubkeyBundlePayload, sigEs384 []byte, sigMldsa87 []byte) error {
 	msg := CanonicalPubkeyBundleMessage(payload)
+	return verifyHybrid(es384Pub, mldsa87PubBytes, msg, sigEs384, sigMldsa87)
+}
+
+// VerifyHybridBundleV2 verifies both legs of the hybrid signature covering the canonical v2 pubkey-bundle message
+// The same SECURITY caveats as VerifyHybridBundle apply: this is a consistency check only, and callers MUST independently bind the anchor pubkeys to the principal they represent
+func VerifyHybridBundleV2(es384Pub *ecdsa.PublicKey, mldsa87PubBytes []byte, payload *PubkeyBundlePayloadV2, sigEs384 []byte, sigMldsa87 []byte) error {
+	if payload.V != PubkeyBundleVersion2 {
+		return fmt.Errorf("unsupported pubkey bundle version %d", payload.V)
+	}
+	msg := CanonicalPubkeyBundleMessageV2(payload)
 	return verifyHybrid(es384Pub, mldsa87PubBytes, msg, sigEs384, sigMldsa87)
 }
 

--- a/pkg/protocolv2/anchor.go
+++ b/pkg/protocolv2/anchor.go
@@ -27,9 +27,11 @@ const (
 )
 
 // Pubkey bundle signature versions
-// The bundle is hybrid-signed exactly once, in the browser at signup; the anchor and request-encryption pubkeys it covers are immutable afterwards, so the signature is never regenerated
-// Version 1 (legacy) bound the user's wrapped-key epoch into the signed payload, which was always 1 at signup; the live epoch advances on password changes (it tracks re-wraps of the primary key, not the bundle), so verifiers of v1 bundles must reconstruct the payload with PubkeyBundleWrappedKeyEpoch, NOT the user's current epoch
-// Version 2 drops the epoch entirely and instead binds an explicit `v` line, so the signed bytes carry an authenticated format version
+// The bundle is hybrid-signed exactly once, in the browser at signup
+// The anchor and request-encryption pubkeys it covers are immutable afterwards, so the signature is never regenerated
+// V1 (legacy) bound the user's wrapped-key epoch into the signed payload, which was always 1 at signup
+// The live epoch advances on password changes (it tracks re-wraps of the primary key, not the bundle), so verifiers of v1 bundles must reconstruct the payload with PubkeyBundleWrappedKeyEpoch, NOT the user's current epoch
+// V2 drops the epoch entirely and instead binds an explicit `v` line, so the signed bytes carry an authenticated format version
 const (
 	PubkeyBundleVersion1 int64 = 1
 	PubkeyBundleVersion2 int64 = 2
@@ -49,7 +51,7 @@ const (
 )
 
 // AttestationPayload is the canonicalized payload that the anchor signs when a new credential is enrolled
-// The order is load-bearing: client and server must produce identical bytes
+// The order is critical: client and server must produce identical bytes
 type AttestationPayload struct {
 	UserID                  string `key:"userId"`
 	CredentialID            string `key:"credentialId"`
@@ -97,7 +99,7 @@ func ParseAttestationPayload(body string) (AttestationPayload, error) {
 }
 
 // PubkeyBundlePayload is the canonicalized payload that the anchor signs to bind the user's long-lived transport pubkeys and the anchor pubkeys together into a single hybrid-signed bundle
-// The order is load-bearing: client and server must produce identical bytes
+// The order is critical: client and server must produce identical bytes
 // The ES384 anchor pubkey is flattened to its JWK members (crv, kty, x, y) so every field stays on a single line, consistent with every other key=value canonical body in this codebase
 type PubkeyBundlePayload struct {
 	UserID                 string `key:"userId"`
@@ -164,9 +166,9 @@ func ParsePubkeyBundlePayload(body string) (PubkeyBundlePayload, error) {
 	return p, nil
 }
 
-// PubkeyBundlePayloadV2 is the version-2 canonicalized pubkey-bundle payload
-// It replaces the legacy wrappedKeyEpoch line (which carried no verifiable meaning — the bundle is signed once at signup and the epoch tracks unrelated key re-wraps) with an explicit `v` line, so the signed bytes carry an authenticated format version
-// The order is load-bearing: client and server must produce identical bytes; `v` is last, matching SigningKeyPublicationPayload
+// PubkeyBundlePayloadV2 is the v2 canonicalized pubkey-bundle payload
+// It replaces the legacy wrappedKeyEpoch line (which carried no actual _raison d'etre_) with an explicit `v` line, so the signed bytes carry an authenticated format version
+// The order is critical: client and server must produce identical bytes
 type PubkeyBundlePayloadV2 struct {
 	UserID                 string `key:"userId"`
 	RequestEncEcdhPubkey   string `key:"requestEncEcdhPubkey"`
@@ -295,11 +297,12 @@ func VerifyHybridBundle(es384Pub *ecdsa.PublicKey, mldsa87PubBytes []byte, paylo
 }
 
 // VerifyHybridBundleV2 verifies both legs of the hybrid signature covering the canonical v2 pubkey-bundle message
-// The same SECURITY caveats as VerifyHybridBundle apply: this is a consistency check only, and callers MUST independently bind the anchor pubkeys to the principal they represent
+// The same security caveats as VerifyHybridBundle apply: this is a consistency check only, and callers MUST independently bind the anchor pubkeys to the principal they represent
 func VerifyHybridBundleV2(es384Pub *ecdsa.PublicKey, mldsa87PubBytes []byte, payload *PubkeyBundlePayloadV2, sigEs384 []byte, sigMldsa87 []byte) error {
 	if payload.V != PubkeyBundleVersion2 {
 		return fmt.Errorf("unsupported pubkey bundle version %d", payload.V)
 	}
+
 	msg := CanonicalPubkeyBundleMessageV2(payload)
 	return verifyHybrid(es384Pub, mldsa87PubBytes, msg, sigEs384, sigMldsa87)
 }

--- a/pkg/protocolv2/anchor_test.go
+++ b/pkg/protocolv2/anchor_test.go
@@ -40,6 +40,20 @@ func testBundlePayload() *PubkeyBundlePayload {
 	}
 }
 
+func testBundlePayloadV2() *PubkeyBundlePayloadV2 {
+	return &PubkeyBundlePayloadV2{
+		UserID:                 "user-123",
+		RequestEncEcdhPubkey:   `{"kty":"EC","crv":"P-256","x":"xxx","y":"yyy"}`,
+		RequestEncMlkemPubkey:  base64.RawURLEncoding.EncodeToString([]byte("mlkem-pub-bytes")),
+		AnchorEs384Crv:         "P-384",
+		AnchorEs384Kty:         "EC",
+		AnchorEs384X:           "aaa",
+		AnchorEs384Y:           "bbb",
+		AnchorMldsa87PublicKey: base64.RawURLEncoding.EncodeToString([]byte("mldsa87-pub-bytes")),
+		V:                      PubkeyBundleVersion2,
+	}
+}
+
 func signES384Raw(t *testing.T, priv *ecdsa.PrivateKey, msg []byte) []byte {
 	t.Helper()
 	digest := sha512.Sum384(msg)
@@ -224,6 +238,35 @@ func TestParsePubkeyBundlePayloadRejectsMalformed(t *testing.T) {
 	}
 }
 
+func TestPubkeyBundlePayloadV2CanonicalBody(t *testing.T) {
+	body := testBundlePayloadV2().CanonicalBody()
+	expected := "userId=user-123\n" +
+		`requestEncEcdhPubkey={"kty":"EC","crv":"P-256","x":"xxx","y":"yyy"}` + "\n" +
+		"requestEncMlkemPubkey=" + base64.RawURLEncoding.EncodeToString([]byte("mlkem-pub-bytes")) + "\n" +
+		"anchorEs384Crv=P-384\n" +
+		"anchorEs384Kty=EC\n" +
+		"anchorEs384X=aaa\n" +
+		"anchorEs384Y=bbb\n" +
+		"anchorMldsa87PublicKey=" + base64.RawURLEncoding.EncodeToString([]byte("mldsa87-pub-bytes")) + "\n" +
+		"v=2"
+	require.Equal(t, expected, body)
+}
+
+func TestParsePubkeyBundlePayloadV2RoundTrip(t *testing.T) {
+	in := testBundlePayloadV2()
+	out, err := ParsePubkeyBundlePayloadV2(in.CanonicalBody())
+	require.NoError(t, err)
+	require.Equal(t, *in, out)
+}
+
+func TestParsePubkeyBundlePayloadV2RejectsV1Body(t *testing.T) {
+	// A v1 canonical body (ends with wrappedKeyEpoch=...) must not parse as v2, and vice versa: the strict key check is what keeps the two formats unambiguous under the shared domain-separation prefix
+	_, err := ParsePubkeyBundlePayloadV2(testBundlePayload().CanonicalBody())
+	require.Error(t, err)
+	_, err = ParsePubkeyBundlePayload(testBundlePayloadV2().CanonicalBody())
+	require.Error(t, err)
+}
+
 func TestHybridAttestationRoundTrip(t *testing.T) {
 	esPriv, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	require.NoError(t, err)
@@ -295,6 +338,34 @@ func TestHybridBundleRoundTripAndTamper(t *testing.T) {
 	tamp.AnchorEs384X = "malicious"
 	err = VerifyHybridBundle(&esPriv.PublicKey, mlPubBytes, tamp, sigEs, sigMl)
 	require.Error(t, err)
+}
+
+func TestHybridBundleV2RoundTripAndTamper(t *testing.T) {
+	esPriv, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	require.NoError(t, err)
+	mlPub, mlPriv, err := mldsa87.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	mlPubBytes, err := mlPub.MarshalBinary()
+	require.NoError(t, err)
+
+	payload := testBundlePayloadV2()
+	msg := CanonicalPubkeyBundleMessageV2(payload)
+	sigEs := signES384Raw(t, esPriv, msg)
+	sigMl := signMLDSA87(t, mlPriv, msg)
+
+	require.NoError(t, VerifyHybridBundleV2(&esPriv.PublicKey, mlPubBytes, payload, sigEs, sigMl))
+
+	// Swapping the anchor ES384 pubkey inside the payload breaks both sigs.
+	tamp := *payload
+	tamp.AnchorEs384X = "malicious"
+	err = VerifyHybridBundleV2(&esPriv.PublicKey, mlPubBytes, &tamp, sigEs, sigMl)
+	require.Error(t, err)
+
+	// A claimed version other than 2 is rejected before any signature check.
+	wrongV := *payload
+	wrongV.V = 3
+	err = VerifyHybridBundleV2(&esPriv.PublicKey, mlPubBytes, &wrongV, sigEs, sigMl)
+	require.ErrorContains(t, err, "unsupported pubkey bundle version")
 }
 
 func TestAnchorFingerprintStable(t *testing.T) {

--- a/pkg/protocolv2/anchor_test.go
+++ b/pkg/protocolv2/anchor_test.go
@@ -263,6 +263,7 @@ func TestParsePubkeyBundlePayloadV2RejectsV1Body(t *testing.T) {
 	// A v1 canonical body (ends with wrappedKeyEpoch=...) must not parse as v2, and vice versa: the strict key check is what keeps the two formats unambiguous under the shared domain-separation prefix
 	_, err := ParsePubkeyBundlePayloadV2(testBundlePayload().CanonicalBody())
 	require.Error(t, err)
+
 	_, err = ParsePubkeyBundlePayload(testBundlePayloadV2().CanonicalBody())
 	require.Error(t, err)
 }

--- a/pkg/server/e2e_routes_testbuild.go
+++ b/pkg/server/e2e_routes_testbuild.go
@@ -230,6 +230,7 @@ func (s *Server) RouteE2ESeedUser(c *gin.Context) {
 						WrappedPrimaryKey:     wrappedKey,
 						RequestEncEcdhPubkey:  string(requestEncJWKJSON),
 						RequestEncMlkemPubkey: base64.RawURLEncoding.EncodeToString([]byte("test-mlkem-pubkey-" + req.UserID)),
+						PubkeyBundleVersion:   2,
 					},
 				)
 				if err != nil && !errors.Is(err, db.ErrAlreadyFinalized) {

--- a/pkg/server/routes-auth.go
+++ b/pkg/server/routes-auth.go
@@ -108,8 +108,10 @@ type v2AuthFinalizeSignupRequest struct {
 	AnchorMldsa87PublicKey string `json:"anchorMldsa87PublicKey"`
 
 	// Self-signatures by the anchor over the canonical pubkey bundle
+	// pubkeyBundleVersion selects the canonical payload the signatures cover: 1 (legacy, binds wrappedKeyEpoch; the default when omitted) or 2 (binds an explicit v line)
 	PubkeyBundleSignatureEs384   string `json:"pubkeyBundleSignatureEs384"`
 	PubkeyBundleSignatureMldsa87 string `json:"pubkeyBundleSignatureMldsa87"`
+	PubkeyBundleVersion          int64  `json:"pubkeyBundleVersion"`
 
 	// First-credential attestation signed by the anchor
 	WrappedAnchorKey            string `json:"wrappedAnchorKey"`
@@ -1760,25 +1762,9 @@ func (s *Server) finalizeSetup(c *gin.Context, tx *db.DbTx, vals finalizeSetupVa
 
 	// Bundle self-signature: the anchor signs its own wire-format representation
 	// This is what the CLI verifies on every request
-	es384JWK, err := protocolv2.ParseECP384PublicJWKCanonicalBody(vals.req.AnchorEs384PublicKey)
+	bundleVersion, err := verifySignupPubkeyBundle(vals)
 	if err != nil {
-		return finalizeSetupRes{}, NewResponseErrorf(http.StatusBadRequest, "invalid anchorEs384PublicKey: %v", err)
-	}
-
-	bundlePayload := &protocolv2.PubkeyBundlePayload{
-		UserID:                 vals.userID,
-		RequestEncEcdhPubkey:   string(vals.req.RequestEncEcdhPubkey),
-		RequestEncMlkemPubkey:  vals.req.RequestEncMlkemPubkey,
-		AnchorEs384Crv:         es384JWK.Crv,
-		AnchorEs384Kty:         es384JWK.Kty,
-		AnchorEs384X:           es384JWK.X,
-		AnchorEs384Y:           es384JWK.Y,
-		AnchorMldsa87PublicKey: vals.req.AnchorMldsa87PublicKey,
-		WrappedKeyEpoch:        protocolv2.PubkeyBundleWrappedKeyEpoch,
-	}
-	err = protocolv2.VerifyHybridBundle(vals.anchorEs384Pub, vals.mldsa87PubBytes, bundlePayload, vals.bundleSigEs, vals.bundleSigMl)
-	if err != nil {
-		return finalizeSetupRes{}, NewResponseErrorf(http.StatusBadRequest, "pubkey bundle signature verification failed: %v", err)
+		return finalizeSetupRes{}, err
 	}
 
 	// Verify the hybrid attestation signature first, then compare every signed field against server-derived expected values
@@ -1818,6 +1804,7 @@ func (s *Server) finalizeSetup(c *gin.Context, tx *db.DbTx, vals finalizeSetupVa
 		AnchorMldsa87PublicKey:       vals.req.AnchorMldsa87PublicKey,
 		PubkeyBundleSignatureEs384:   vals.req.PubkeyBundleSignatureEs384,
 		PubkeyBundleSignatureMldsa87: vals.req.PubkeyBundleSignatureMldsa87,
+		PubkeyBundleVersion:          bundleVersion,
 		AttestationPayload:           vals.req.AttestationPayload,
 		AttestationSignatureEs384:    vals.req.AttestationSignatureEs384,
 		AttestationSignatureMldsa87:  vals.req.AttestationSignatureMldsa87,
@@ -1850,6 +1837,57 @@ func (s *Server) finalizeSetup(c *gin.Context, tx *db.DbTx, vals finalizeSetupVa
 	return finalizeSetupRes{
 		user: user,
 	}, nil
+}
+
+// verifySignupPubkeyBundle reconstructs the canonical pubkey-bundle payload for the version requested at signup and verifies both hybrid signature legs
+// Returns the normalized version (an omitted version means the legacy v1 payload) that must be stored alongside the signatures, so verifiers can later rebuild the exact signed bytes
+func verifySignupPubkeyBundle(vals finalizeSetupVals) (int64, error) {
+	es384JWK, err := protocolv2.ParseECP384PublicJWKCanonicalBody(vals.req.AnchorEs384PublicKey)
+	if err != nil {
+		return 0, NewResponseErrorf(http.StatusBadRequest, "invalid anchorEs384PublicKey: %v", err)
+	}
+
+	version := vals.req.PubkeyBundleVersion
+	if version == 0 {
+		version = protocolv2.PubkeyBundleVersion1
+	}
+
+	switch version {
+	case protocolv2.PubkeyBundleVersion1:
+		// Legacy payload: binds the wrapped-key epoch, which is always 1 at signup and stays 1 in the signed bytes forever (the live epoch advances on password changes but the bundle is never re-signed)
+		bundlePayload := &protocolv2.PubkeyBundlePayload{
+			UserID:                 vals.userID,
+			RequestEncEcdhPubkey:   string(vals.req.RequestEncEcdhPubkey),
+			RequestEncMlkemPubkey:  vals.req.RequestEncMlkemPubkey,
+			AnchorEs384Crv:         es384JWK.Crv,
+			AnchorEs384Kty:         es384JWK.Kty,
+			AnchorEs384X:           es384JWK.X,
+			AnchorEs384Y:           es384JWK.Y,
+			AnchorMldsa87PublicKey: vals.req.AnchorMldsa87PublicKey,
+			WrappedKeyEpoch:        protocolv2.PubkeyBundleWrappedKeyEpoch,
+		}
+		err = protocolv2.VerifyHybridBundle(vals.anchorEs384Pub, vals.mldsa87PubBytes, bundlePayload, vals.bundleSigEs, vals.bundleSigMl)
+	case protocolv2.PubkeyBundleVersion2:
+		bundlePayload := &protocolv2.PubkeyBundlePayloadV2{
+			UserID:                 vals.userID,
+			RequestEncEcdhPubkey:   string(vals.req.RequestEncEcdhPubkey),
+			RequestEncMlkemPubkey:  vals.req.RequestEncMlkemPubkey,
+			AnchorEs384Crv:         es384JWK.Crv,
+			AnchorEs384Kty:         es384JWK.Kty,
+			AnchorEs384X:           es384JWK.X,
+			AnchorEs384Y:           es384JWK.Y,
+			AnchorMldsa87PublicKey: vals.req.AnchorMldsa87PublicKey,
+			V:                      protocolv2.PubkeyBundleVersion2,
+		}
+		err = protocolv2.VerifyHybridBundleV2(vals.anchorEs384Pub, vals.mldsa87PubBytes, bundlePayload, vals.bundleSigEs, vals.bundleSigMl)
+	default:
+		return 0, NewResponseErrorf(http.StatusBadRequest, "unsupported pubkeyBundleVersion %d", version)
+	}
+	if err != nil {
+		return 0, NewResponseErrorf(http.StatusBadRequest, "pubkey bundle signature verification failed: %v", err)
+	}
+
+	return version, nil
 }
 
 func (s *Server) validateAuthenticatorSignCount(c *gin.Context, userRecord *v2WebAuthnUser, cred *webauthnlib.Credential) error {

--- a/pkg/server/routes-auth.go
+++ b/pkg/server/routes-auth.go
@@ -1774,7 +1774,7 @@ func (s *Server) finalizeSetup(c *gin.Context, tx *db.DbTx, vals finalizeSetupVa
 		AnchorEs384X:           es384JWK.X,
 		AnchorEs384Y:           es384JWK.Y,
 		AnchorMldsa87PublicKey: vals.req.AnchorMldsa87PublicKey,
-		WrappedKeyEpoch:        1,
+		WrappedKeyEpoch:        protocolv2.PubkeyBundleWrappedKeyEpoch,
 	}
 	err = protocolv2.VerifyHybridBundle(vals.anchorEs384Pub, vals.mldsa87PubBytes, bundlePayload, vals.bundleSigEs, vals.bundleSigMl)
 	if err != nil {

--- a/pkg/server/routes-auth.go
+++ b/pkg/server/routes-auth.go
@@ -108,7 +108,6 @@ type v2AuthFinalizeSignupRequest struct {
 	AnchorMldsa87PublicKey string `json:"anchorMldsa87PublicKey"`
 
 	// Self-signatures by the anchor over the canonical pubkey bundle
-	// pubkeyBundleVersion selects the canonical payload the signatures cover: 1 (legacy, binds wrappedKeyEpoch; the default when omitted) or 2 (binds an explicit v line)
 	PubkeyBundleSignatureEs384   string `json:"pubkeyBundleSignatureEs384"`
 	PubkeyBundleSignatureMldsa87 string `json:"pubkeyBundleSignatureMldsa87"`
 	PubkeyBundleVersion          int64  `json:"pubkeyBundleVersion"`
@@ -1847,6 +1846,7 @@ func verifySignupPubkeyBundle(vals finalizeSetupVals) (int64, error) {
 		return 0, NewResponseErrorf(http.StatusBadRequest, "invalid anchorEs384PublicKey: %v", err)
 	}
 
+	// If the client did not provide a bundle version, assume legacy version 1
 	version := vals.req.PubkeyBundleVersion
 	if version == 0 {
 		version = protocolv2.PubkeyBundleVersion1

--- a/pkg/server/routes-request.go
+++ b/pkg/server/routes-request.go
@@ -40,9 +40,12 @@ type v2RequestPubkeyResponse struct {
 
 	// Hybrid anchor pubkeys + bundle self-signatures
 	// The CLI pins the anchor pubkeys (TOFU) and verifies both signatures over the bundle to detect server-side pubkey substitution attacks
+	// pubkeyBundleVersion tells the verifier which canonical payload the signatures cover: 1 (legacy, binds wrappedKeyEpoch) or 2 (binds an explicit v line)
+	// wrappedKeyEpoch is retained for CLIs that predate versioning and only ever reflects the epoch bound into v1 signatures (always 1), NOT the user's live epoch
 	AnchorEs384PublicKey         string `json:"anchorEs384PublicKey"`
 	AnchorMldsa87PublicKey       string `json:"anchorMldsa87PublicKey"`
 	WrappedKeyEpoch              int64  `json:"wrappedKeyEpoch"`
+	PubkeyBundleVersion          int64  `json:"pubkeyBundleVersion"`
 	PubkeyBundleSignatureEs384   string `json:"pubkeyBundleSignatureEs384"`
 	PubkeyBundleSignatureMldsa87 string `json:"pubkeyBundleSignatureMldsa87"`
 }
@@ -224,7 +227,7 @@ func (s *Server) RouteV2RequestPubkey(c *gin.Context) {
 	}
 
 	// Send the response
-	// WrappedKeyEpoch must be the epoch bound into the stored bundle signature (always PubkeyBundleWrappedKeyEpoch), not the user's live epoch: the bundle is signed once at signup and never re-signed, while the live epoch advances on every password change, which would make the CLI's signature verification fail
+	// WrappedKeyEpoch must be the epoch bound into v1 bundle signatures (always PubkeyBundleWrappedKeyEpoch), not the user's live epoch: the bundle is signed once at signup and never re-signed, while the live epoch advances on every password change, which would make the CLI's signature verification fail
 	c.JSON(http.StatusOK, v2RequestPubkeyResponse{
 		UserID:                       user.ID,
 		EcdhP256:                     json.RawMessage(user.RequestEncEcdhPubkey),
@@ -232,6 +235,7 @@ func (s *Server) RouteV2RequestPubkey(c *gin.Context) {
 		AnchorEs384PublicKey:         user.AnchorEs384PublicKey,
 		AnchorMldsa87PublicKey:       user.AnchorMldsa87PublicKey,
 		WrappedKeyEpoch:              protocolv2.PubkeyBundleWrappedKeyEpoch,
+		PubkeyBundleVersion:          user.PubkeyBundleVersion,
 		PubkeyBundleSignatureEs384:   user.PubkeyBundleSignatureEs384,
 		PubkeyBundleSignatureMldsa87: user.PubkeyBundleSignatureMldsa87,
 	})

--- a/pkg/server/routes-request.go
+++ b/pkg/server/routes-request.go
@@ -224,13 +224,14 @@ func (s *Server) RouteV2RequestPubkey(c *gin.Context) {
 	}
 
 	// Send the response
+	// WrappedKeyEpoch must be the epoch bound into the stored bundle signature (always PubkeyBundleWrappedKeyEpoch), not the user's live epoch: the bundle is signed once at signup and never re-signed, while the live epoch advances on every password change, which would make the CLI's signature verification fail
 	c.JSON(http.StatusOK, v2RequestPubkeyResponse{
 		UserID:                       user.ID,
 		EcdhP256:                     json.RawMessage(user.RequestEncEcdhPubkey),
 		Mlkem768:                     user.RequestEncMlkemPubkey,
 		AnchorEs384PublicKey:         user.AnchorEs384PublicKey,
 		AnchorMldsa87PublicKey:       user.AnchorMldsa87PublicKey,
-		WrappedKeyEpoch:              user.WrappedKeyEpoch,
+		WrappedKeyEpoch:              protocolv2.PubkeyBundleWrappedKeyEpoch,
 		PubkeyBundleSignatureEs384:   user.PubkeyBundleSignatureEs384,
 		PubkeyBundleSignatureMldsa87: user.PubkeyBundleSignatureMldsa87,
 	})

--- a/pkg/server/routes-request.go
+++ b/pkg/server/routes-request.go
@@ -40,10 +40,9 @@ type v2RequestPubkeyResponse struct {
 
 	// Hybrid anchor pubkeys + bundle self-signatures
 	// The CLI pins the anchor pubkeys (TOFU) and verifies both signatures over the bundle to detect server-side pubkey substitution attacks
-	// pubkeyBundleVersion tells the verifier which canonical payload the signatures cover: 1 (legacy, binds wrappedKeyEpoch) or 2 (binds an explicit v line)
+	AnchorEs384PublicKey   string `json:"anchorEs384PublicKey"`
+	AnchorMldsa87PublicKey string `json:"anchorMldsa87PublicKey"`
 	// wrappedKeyEpoch is retained for CLIs that predate versioning and only ever reflects the epoch bound into v1 signatures (always 1), NOT the user's live epoch
-	AnchorEs384PublicKey         string `json:"anchorEs384PublicKey"`
-	AnchorMldsa87PublicKey       string `json:"anchorMldsa87PublicKey"`
 	WrappedKeyEpoch              int64  `json:"wrappedKeyEpoch"`
 	PubkeyBundleVersion          int64  `json:"pubkeyBundleVersion"`
 	PubkeyBundleSignatureEs384   string `json:"pubkeyBundleSignatureEs384"`

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1264,6 +1264,31 @@ func signSigningKeyPublication(t *testing.T, anchor *testAnchorKeyPair, payload 
 	return canonicalBody, sigEsB64, sigMlB64
 }
 
+// signPubkeyBundle signs a pubkey-bundle payload under the supplied anchor and returns base64url ES384 + ML-DSA-87 signatures, mirroring what the browser produces at signup
+func signPubkeyBundle(t *testing.T, anchor *testAnchorKeyPair, payload *protocolv2.PubkeyBundlePayload) (sigEsB64, sigMlB64 string) {
+	t.Helper()
+
+	msg := protocolv2.CanonicalPubkeyBundleMessage(payload)
+
+	digest := sha512.Sum384(msg)
+	r, s, err := ecdsa.Sign(rand.Reader, anchor.Es384Priv, digest[:])
+	require.NoError(t, err)
+	sig := make([]byte, protocolv2.ES384SignatureSize)
+	const half = protocolv2.ES384SignatureSize / 2
+	rBytes := r.Bytes()
+	sBytes := s.Bytes()
+	copy(sig[half-len(rBytes):half], rBytes)
+	copy(sig[protocolv2.ES384SignatureSize-len(sBytes):], sBytes)
+	sigEsB64 = base64.RawURLEncoding.EncodeToString(sig)
+
+	mlSig := make([]byte, protocolv2.MLDSA87SignatureSize)
+	err = mldsa87.SignTo(anchor.Mldsa87Priv, msg, nil, false, mlSig)
+	require.NoError(t, err)
+	sigMlB64 = base64.RawURLEncoding.EncodeToString(mlSig)
+
+	return sigEsB64, sigMlB64
+}
+
 func startTestServer(t *testing.T, srv *Server) {
 	t.Helper()
 
@@ -1692,4 +1717,83 @@ func TestServerV2CredentialLifecycle(t *testing.T) {
 		res2.Body.Close()
 	}()
 	require.Equal(t, http.StatusNotFound, res2.StatusCode)
+}
+
+// Regression test for https://github.com/ItalyPaleAle/revaulter/issues/23
+// The pubkey bundle is signed once at signup with wrappedKeyEpoch=1 and never re-signed, so after the user's live epoch advances (e.g. a password change rotated the wrapped keys) the /v2/request/pubkey response must still advertise the epoch the signature was created over, or the CLI's verification of the otherwise-valid bundle fails
+func TestServerV2RequestPubkeyBundleVerifiesAfterEpochAdvance(t *testing.T) {
+	setTestConfig(t, "v2-pubkey-epoch.db")
+
+	srv := newTestServer(t, nil, nil, nil)
+	require.NotNil(t, srv)
+
+	startTestServer(t, srv)
+	client := clientForListener(srv.appListener)
+
+	_, user := seedV2SessionCookie(t, srv, "user-pubkey-epoch", "Pubkey Epoch")
+	anchor := seedV2AnchorForUser(t, srv, user.ID)
+
+	// Sign the bundle over the stored request-enc pubkeys at the bundle epoch, as the browser does at signup, and store the signatures like finalize-signup would
+	es384JWK, err := protocolv2.ParseECP384PublicJWKCanonicalBody(anchor.Es384JWKBody)
+	require.NoError(t, err)
+	signedPayload := &protocolv2.PubkeyBundlePayload{
+		UserID:                 user.ID,
+		RequestEncEcdhPubkey:   user.RequestEncEcdhPubkey,
+		RequestEncMlkemPubkey:  user.RequestEncMlkemPubkey,
+		AnchorEs384Crv:         es384JWK.Crv,
+		AnchorEs384Kty:         es384JWK.Kty,
+		AnchorEs384X:           es384JWK.X,
+		AnchorEs384Y:           es384JWK.Y,
+		AnchorMldsa87PublicKey: anchor.Mldsa87PubBase64,
+		WrappedKeyEpoch:        protocolv2.PubkeyBundleWrappedKeyEpoch,
+	}
+	sigEsB64, sigMlB64 := signPubkeyBundle(t, anchor, signedPayload)
+	_, err = srv.db.Exec(t.Context(),
+		`UPDATE v2_users SET pubkey_bundle_signature_es384 = $1, pubkey_bundle_signature_mldsa87 = $2 WHERE id = $3`,
+		sigEsB64, sigMlB64, user.ID,
+	)
+	require.NoError(t, err)
+
+	// Advance the user's wrapped-key epoch, like a password change with advanceEpoch does
+	newEpoch, err := srv.db.AuthStore().AdvanceWrappedKeyEpoch(t.Context(), user.ID)
+	require.NoError(t, err)
+	require.Greater(t, newEpoch, protocolv2.PubkeyBundleWrappedKeyEpoch)
+
+	// Fetch the pubkey bundle like the CLI does
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, fmt.Sprintf("https://localhost:%d/v2/request/pubkey", testServerPort), nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+user.RequestKey)
+	res, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() {
+		_, _ = io.Copy(io.Discard, res.Body)
+		res.Body.Close()
+	}()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	var resp v2RequestPubkeyResponse
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&resp))
+
+	// The advertised epoch must be the one bound into the signature, not the advanced live epoch
+	require.Equal(t, protocolv2.PubkeyBundleWrappedKeyEpoch, resp.WrappedKeyEpoch)
+
+	// Reconstruct the payload from the response exactly like a CLI that trusts the advertised epoch, and verify both signature legs
+	respJWK, err := protocolv2.ParseECP384PublicJWKCanonicalBody(resp.AnchorEs384PublicKey)
+	require.NoError(t, err)
+	verifyPayload := &protocolv2.PubkeyBundlePayload{
+		UserID:                 resp.UserID,
+		RequestEncEcdhPubkey:   string(resp.EcdhP256),
+		RequestEncMlkemPubkey:  resp.Mlkem768,
+		AnchorEs384Crv:         respJWK.Crv,
+		AnchorEs384Kty:         respJWK.Kty,
+		AnchorEs384X:           respJWK.X,
+		AnchorEs384Y:           respJWK.Y,
+		AnchorMldsa87PublicKey: resp.AnchorMldsa87PublicKey,
+		WrappedKeyEpoch:        resp.WrappedKeyEpoch,
+	}
+	es384Pub, mldsa87PubBytes, err := parseAnchorPubkeys(resp.AnchorEs384PublicKey, resp.AnchorMldsa87PublicKey)
+	require.NoError(t, err)
+	sigEs, sigMl, err := parseHybridSignatures(resp.PubkeyBundleSignatureEs384, resp.PubkeyBundleSignatureMldsa87)
+	require.NoError(t, err)
+	require.NoError(t, protocolv2.VerifyHybridBundle(es384Pub, mldsa87PubBytes, verifyPayload, sigEs, sigMl))
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1264,11 +1264,21 @@ func signSigningKeyPublication(t *testing.T, anchor *testAnchorKeyPair, payload 
 	return canonicalBody, sigEsB64, sigMlB64
 }
 
-// signPubkeyBundle signs a pubkey-bundle payload under the supplied anchor and returns base64url ES384 + ML-DSA-87 signatures, mirroring what the browser produces at signup
+// signPubkeyBundle signs a legacy (v1) pubkey-bundle payload under the supplied anchor and returns base64url ES384 + ML-DSA-87 signatures, mirroring what the browser produces at signup
 func signPubkeyBundle(t *testing.T, anchor *testAnchorKeyPair, payload *protocolv2.PubkeyBundlePayload) (sigEsB64, sigMlB64 string) {
 	t.Helper()
+	return signHybridMessage(t, anchor, protocolv2.CanonicalPubkeyBundleMessage(payload))
+}
 
-	msg := protocolv2.CanonicalPubkeyBundleMessage(payload)
+// signPubkeyBundleV2 signs a v2 pubkey-bundle payload under the supplied anchor and returns base64url ES384 + ML-DSA-87 signatures, mirroring what the browser produces at signup
+func signPubkeyBundleV2(t *testing.T, anchor *testAnchorKeyPair, payload *protocolv2.PubkeyBundlePayloadV2) (sigEsB64, sigMlB64 string) {
+	t.Helper()
+	return signHybridMessage(t, anchor, protocolv2.CanonicalPubkeyBundleMessageV2(payload))
+}
+
+// signHybridMessage signs a canonical (already domain-separated) message with both anchor legs and returns base64url-encoded signatures
+func signHybridMessage(t *testing.T, anchor *testAnchorKeyPair, msg []byte) (sigEsB64, sigMlB64 string) {
+	t.Helper()
 
 	digest := sha512.Sum384(msg)
 	r, s, err := ecdsa.Sign(rand.Reader, anchor.Es384Priv, digest[:])
@@ -1774,8 +1784,9 @@ func TestServerV2RequestPubkeyBundleVerifiesAfterEpochAdvance(t *testing.T) {
 	var resp v2RequestPubkeyResponse
 	require.NoError(t, json.NewDecoder(res.Body).Decode(&resp))
 
-	// The advertised epoch must be the one bound into the signature, not the advanced live epoch
+	// The advertised epoch must be the one bound into the signature, not the advanced live epoch, and the row seeded without an explicit version must advertise the legacy v1 format
 	require.Equal(t, protocolv2.PubkeyBundleWrappedKeyEpoch, resp.WrappedKeyEpoch)
+	require.Equal(t, protocolv2.PubkeyBundleVersion1, resp.PubkeyBundleVersion)
 
 	// Reconstruct the payload from the response exactly like a CLI that trusts the advertised epoch, and verify both signature legs
 	respJWK, err := protocolv2.ParseECP384PublicJWKCanonicalBody(resp.AnchorEs384PublicKey)
@@ -1796,4 +1807,174 @@ func TestServerV2RequestPubkeyBundleVerifiesAfterEpochAdvance(t *testing.T) {
 	sigEs, sigMl, err := parseHybridSignatures(resp.PubkeyBundleSignatureEs384, resp.PubkeyBundleSignatureMldsa87)
 	require.NoError(t, err)
 	require.NoError(t, protocolv2.VerifyHybridBundle(es384Pub, mldsa87PubBytes, verifyPayload, sigEs, sigMl))
+}
+
+// Same regression scenario as above, but for a user whose bundle was signed with the v2 payload (explicit v line, no epoch): the response must advertise version 2 and the reconstructed v2 payload must verify regardless of the user's live epoch
+func TestServerV2RequestPubkeyBundleV2VerifiesAfterEpochAdvance(t *testing.T) {
+	setTestConfig(t, "v2-pubkey-epoch-v2.db")
+
+	srv := newTestServer(t, nil, nil, nil)
+	require.NotNil(t, srv)
+
+	startTestServer(t, srv)
+	client := clientForListener(srv.appListener)
+
+	_, user := seedV2SessionCookie(t, srv, "user-pubkey-epoch-v2", "Pubkey Epoch V2")
+	anchor := seedV2AnchorForUser(t, srv, user.ID)
+
+	es384JWK, err := protocolv2.ParseECP384PublicJWKCanonicalBody(anchor.Es384JWKBody)
+	require.NoError(t, err)
+	signedPayload := &protocolv2.PubkeyBundlePayloadV2{
+		UserID:                 user.ID,
+		RequestEncEcdhPubkey:   user.RequestEncEcdhPubkey,
+		RequestEncMlkemPubkey:  user.RequestEncMlkemPubkey,
+		AnchorEs384Crv:         es384JWK.Crv,
+		AnchorEs384Kty:         es384JWK.Kty,
+		AnchorEs384X:           es384JWK.X,
+		AnchorEs384Y:           es384JWK.Y,
+		AnchorMldsa87PublicKey: anchor.Mldsa87PubBase64,
+		V:                      protocolv2.PubkeyBundleVersion2,
+	}
+	sigEsB64, sigMlB64 := signPubkeyBundleV2(t, anchor, signedPayload)
+	_, err = srv.db.Exec(t.Context(),
+		`UPDATE v2_users SET pubkey_bundle_signature_es384 = $1, pubkey_bundle_signature_mldsa87 = $2, pubkey_bundle_version = $3 WHERE id = $4`,
+		sigEsB64, sigMlB64, protocolv2.PubkeyBundleVersion2, user.ID,
+	)
+	require.NoError(t, err)
+
+	// Advance the user's wrapped-key epoch, like a password change with advanceEpoch does
+	_, err = srv.db.AuthStore().AdvanceWrappedKeyEpoch(t.Context(), user.ID)
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, fmt.Sprintf("https://localhost:%d/v2/request/pubkey", testServerPort), nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+user.RequestKey)
+	res, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() {
+		_, _ = io.Copy(io.Discard, res.Body)
+		res.Body.Close()
+	}()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	var resp v2RequestPubkeyResponse
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&resp))
+	require.Equal(t, protocolv2.PubkeyBundleVersion2, resp.PubkeyBundleVersion)
+
+	// Reconstruct the v2 payload from the response exactly like the CLI does and verify both signature legs
+	respJWK, err := protocolv2.ParseECP384PublicJWKCanonicalBody(resp.AnchorEs384PublicKey)
+	require.NoError(t, err)
+	verifyPayload := &protocolv2.PubkeyBundlePayloadV2{
+		UserID:                 resp.UserID,
+		RequestEncEcdhPubkey:   string(resp.EcdhP256),
+		RequestEncMlkemPubkey:  resp.Mlkem768,
+		AnchorEs384Crv:         respJWK.Crv,
+		AnchorEs384Kty:         respJWK.Kty,
+		AnchorEs384X:           respJWK.X,
+		AnchorEs384Y:           respJWK.Y,
+		AnchorMldsa87PublicKey: resp.AnchorMldsa87PublicKey,
+		V:                      resp.PubkeyBundleVersion,
+	}
+	es384Pub, mldsa87PubBytes, err := parseAnchorPubkeys(resp.AnchorEs384PublicKey, resp.AnchorMldsa87PublicKey)
+	require.NoError(t, err)
+	sigEs, sigMl, err := parseHybridSignatures(resp.PubkeyBundleSignatureEs384, resp.PubkeyBundleSignatureMldsa87)
+	require.NoError(t, err)
+	require.NoError(t, protocolv2.VerifyHybridBundleV2(es384Pub, mldsa87PubBytes, verifyPayload, sigEs, sigMl))
+}
+
+// TestVerifySignupPubkeyBundle exercises the version dispatch used by /v2/auth/finalize-signup: an omitted version means the legacy v1 payload, version 2 selects the v-line payload, anything else is rejected, and signatures over the wrong payload version fail
+func TestVerifySignupPubkeyBundle(t *testing.T) {
+	esPriv, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	require.NoError(t, err)
+	mlPub, mlPriv, err := mldsa87.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	mlPubBytes, err := mlPub.MarshalBinary()
+	require.NoError(t, err)
+	anchor := &testAnchorKeyPair{Es384Priv: esPriv, Mldsa87Priv: mlPriv}
+
+	es384JWK, err := protocolv2.ECP384PublicJWKFromECDSA(&esPriv.PublicKey)
+	require.NoError(t, err)
+	es384Body := es384JWK.CanonicalBody()
+	mlPubB64 := base64.RawURLEncoding.EncodeToString(mlPubBytes)
+
+	const userID = "user-bundle-versions"
+	ecdhJSON := `{"kty":"EC","crv":"P-256","x":"xxx","y":"yyy"}`
+	mlkemB64 := base64.RawURLEncoding.EncodeToString([]byte("mlkem-pub-bytes"))
+
+	newVals := func(version int64, sigEsB64, sigMlB64 string) finalizeSetupVals {
+		sigEs, sigErr := base64.RawURLEncoding.DecodeString(sigEsB64)
+		require.NoError(t, sigErr)
+		sigMl, sigErr := base64.RawURLEncoding.DecodeString(sigMlB64)
+		require.NoError(t, sigErr)
+		return finalizeSetupVals{
+			userID: userID,
+			req: &v2AuthFinalizeSignupRequest{
+				RequestEncEcdhPubkey:   json.RawMessage(ecdhJSON),
+				RequestEncMlkemPubkey:  mlkemB64,
+				AnchorEs384PublicKey:   es384Body,
+				AnchorMldsa87PublicKey: mlPubB64,
+				PubkeyBundleVersion:    version,
+			},
+			anchorEs384Pub:  &esPriv.PublicKey,
+			mldsa87PubBytes: mlPubBytes,
+			bundleSigEs:     sigEs,
+			bundleSigMl:     sigMl,
+		}
+	}
+
+	sigV1Es, sigV1Ml := signPubkeyBundle(t, anchor, &protocolv2.PubkeyBundlePayload{
+		UserID:                 userID,
+		RequestEncEcdhPubkey:   ecdhJSON,
+		RequestEncMlkemPubkey:  mlkemB64,
+		AnchorEs384Crv:         es384JWK.Crv,
+		AnchorEs384Kty:         es384JWK.Kty,
+		AnchorEs384X:           es384JWK.X,
+		AnchorEs384Y:           es384JWK.Y,
+		AnchorMldsa87PublicKey: mlPubB64,
+		WrappedKeyEpoch:        protocolv2.PubkeyBundleWrappedKeyEpoch,
+	})
+	sigV2Es, sigV2Ml := signPubkeyBundleV2(t, anchor, &protocolv2.PubkeyBundlePayloadV2{
+		UserID:                 userID,
+		RequestEncEcdhPubkey:   ecdhJSON,
+		RequestEncMlkemPubkey:  mlkemB64,
+		AnchorEs384Crv:         es384JWK.Crv,
+		AnchorEs384Kty:         es384JWK.Kty,
+		AnchorEs384X:           es384JWK.X,
+		AnchorEs384Y:           es384JWK.Y,
+		AnchorMldsa87PublicKey: mlPubB64,
+		V:                      protocolv2.PubkeyBundleVersion2,
+	})
+
+	t.Run("v1 signature with omitted version", func(t *testing.T) {
+		version, vErr := verifySignupPubkeyBundle(newVals(0, sigV1Es, sigV1Ml))
+		require.NoError(t, vErr)
+		require.Equal(t, protocolv2.PubkeyBundleVersion1, version)
+	})
+
+	t.Run("v1 signature with explicit version", func(t *testing.T) {
+		version, vErr := verifySignupPubkeyBundle(newVals(1, sigV1Es, sigV1Ml))
+		require.NoError(t, vErr)
+		require.Equal(t, protocolv2.PubkeyBundleVersion1, version)
+	})
+
+	t.Run("v2 signature with version 2", func(t *testing.T) {
+		version, vErr := verifySignupPubkeyBundle(newVals(2, sigV2Es, sigV2Ml))
+		require.NoError(t, vErr)
+		require.Equal(t, protocolv2.PubkeyBundleVersion2, version)
+	})
+
+	t.Run("v1 signature claimed as version 2 fails", func(t *testing.T) {
+		_, vErr := verifySignupPubkeyBundle(newVals(2, sigV1Es, sigV1Ml))
+		require.ErrorContains(t, vErr, "signature verification failed")
+	})
+
+	t.Run("v2 signature claimed as version 1 fails", func(t *testing.T) {
+		_, vErr := verifySignupPubkeyBundle(newVals(1, sigV2Es, sigV2Ml))
+		require.ErrorContains(t, vErr, "signature verification failed")
+	})
+
+	t.Run("unsupported version rejected", func(t *testing.T) {
+		_, vErr := verifySignupPubkeyBundle(newVals(3, sigV2Es, sigV2Ml))
+		require.ErrorContains(t, vErr, "unsupported pubkeyBundleVersion")
+	})
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1153,6 +1153,8 @@ func seedV2SessionCookie(t *testing.T, srv *Server, userID string, displayName s
 				WrappedPrimaryKey:     "test-wrapped-primary-key",
 				RequestEncEcdhPubkey:  string(requestEncJWKJSON),
 				RequestEncMlkemPubkey: base64.RawURLEncoding.EncodeToString([]byte("test-mlkem-pubkey")),
+				// Use legacy version
+				PubkeyBundleVersion: 1,
 			},
 		)
 		require.NoError(t, err)
@@ -1169,6 +1171,7 @@ func seedV2SessionCookie(t *testing.T, srv *Server, userID string, displayName s
 	token, err := signAuthSessionToken(signed)
 	require.NoError(t, err)
 
+	//#nosec G124 -- test code
 	return &http.Cookie{
 		Name:  sessionCookieNameSecure,
 		Value: token,
@@ -1267,12 +1270,14 @@ func signSigningKeyPublication(t *testing.T, anchor *testAnchorKeyPair, payload 
 // signPubkeyBundle signs a legacy (v1) pubkey-bundle payload under the supplied anchor and returns base64url ES384 + ML-DSA-87 signatures, mirroring what the browser produces at signup
 func signPubkeyBundle(t *testing.T, anchor *testAnchorKeyPair, payload *protocolv2.PubkeyBundlePayload) (sigEsB64, sigMlB64 string) {
 	t.Helper()
+
 	return signHybridMessage(t, anchor, protocolv2.CanonicalPubkeyBundleMessage(payload))
 }
 
 // signPubkeyBundleV2 signs a v2 pubkey-bundle payload under the supplied anchor and returns base64url ES384 + ML-DSA-87 signatures, mirroring what the browser produces at signup
 func signPubkeyBundleV2(t *testing.T, anchor *testAnchorKeyPair, payload *protocolv2.PubkeyBundlePayloadV2) (sigEsB64, sigMlB64 string) {
 	t.Helper()
+
 	return signHybridMessage(t, anchor, protocolv2.CanonicalPubkeyBundleMessageV2(payload))
 }
 
@@ -1782,7 +1787,8 @@ func TestServerV2RequestPubkeyBundleVerifiesAfterEpochAdvance(t *testing.T) {
 	require.Equal(t, http.StatusOK, res.StatusCode)
 
 	var resp v2RequestPubkeyResponse
-	require.NoError(t, json.NewDecoder(res.Body).Decode(&resp))
+	err = json.NewDecoder(res.Body).Decode(&resp)
+	require.NoError(t, err)
 
 	// The advertised epoch must be the one bound into the signature, not the advanced live epoch, and the row seeded without an explicit version must advertise the legacy v1 format
 	require.Equal(t, protocolv2.PubkeyBundleWrappedKeyEpoch, resp.WrappedKeyEpoch)
@@ -1858,7 +1864,8 @@ func TestServerV2RequestPubkeyBundleV2VerifiesAfterEpochAdvance(t *testing.T) {
 	require.Equal(t, http.StatusOK, res.StatusCode)
 
 	var resp v2RequestPubkeyResponse
-	require.NoError(t, json.NewDecoder(res.Body).Decode(&resp))
+	err = json.NewDecoder(res.Body).Decode(&resp)
+	require.NoError(t, err)
 	require.Equal(t, protocolv2.PubkeyBundleVersion2, resp.PubkeyBundleVersion)
 
 	// Reconstruct the v2 payload from the response exactly like the CLI does and verify both signature legs


### PR DESCRIPTION
## Summary

This PR fixes a regression where pubkey bundle signature verification fails after a user's wrapped-key epoch advances (e.g., during password changes). The bundle is signed once at signup and never re-signed, but servers were incorrectly echoing the user's live epoch in responses, causing verification to fail when the epoch advanced.

The fix introduces versioned pubkey bundle payloads: version 1 (legacy) binds a fixed `wrappedKeyEpoch=1` constant, while version 2 binds an explicit `v` line instead. Verifiers now reconstruct the exact signed payload based on the advertised version, making verification independent of the user's current epoch.

## Key Changes

- **Protocol versioning**: Added `PubkeyBundleVersion1` and `PubkeyBundleVersion2` constants, plus `PubkeyBundlePayloadV2` struct with `v` field instead of `wrappedKeyEpoch`
- **Canonical message generation**: Implemented `CanonicalPubkeyBundleMessageV2()` for v2 payload domain separation and `VerifyHybridBundleV2()` for v2 signature verification
- **Server-side verification**: Added `verifySignupPubkeyBundle()` function that dispatches to the correct verification path based on the claimed version, rejecting mismatches
- **Database schema**: Added `pubkey_bundle_version` column to `v2_users` table to store which version the stored signatures cover
- **CLI verification**: Updated `verifyAndPinAnchor()` to reconstruct v1 payloads with the protocol constant `PubkeyBundleWrappedKeyEpoch` rather than the server-reported epoch, and added support for v2 bundle verification
- **Browser/web client**: Updated signup flow to send `pubkeyBundleVersion=2` when finalizing signup, signing the v2 payload
- **Comprehensive testing**: Added regression tests for both v1 and v2 bundles verifying after epoch advance, version dispatch tests, and CLI-side verification tests

## Notable Implementation Details

- The domain-separation prefix is shared between v1 and v2 formats; they cannot be confused because the canonical bodies differ (v1 ends with `wrappedKeyEpoch=...`, v2 with `v=2`) and parsing is strict about keys and order
- Version 1 bundles are reconstructed with `PubkeyBundleWrappedKeyEpoch=1` constant, making them immune to the user's live epoch advancing
- Version 2 bundles carry an explicit `v` line in the signed payload, providing authenticated format versioning
- Omitted `pubkeyBundleVersion` in requests defaults to version 1 for backward compatibility
- The `wrappedKeyEpoch` field is retained in responses for older CLIs but is ignored by v2-aware verifiers