### PR TITLE
chore: update hugo-assets to v0.3.1

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -7,7 +7,8 @@
   "github": {
     "url": "https://github.com/ItalyPaleAle/revaulter",
     "repo": "https://github.com/ItalyPaleAle/revaulter",
-    "branch": "main"
+    "branch": "main",
+    "path": "docs"
   },
   "theme": {
     "scheme": "rust",

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -4,4 +4,4 @@ go 1.26.3
 
 tool github.com/italypaleale/hugo-assets/cmd/vercel-docs-build
 
-require github.com/italypaleale/hugo-assets v0.3.0 // indirect
+require github.com/italypaleale/hugo-assets v0.3.1 // indirect

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -1,2 +1,2 @@
-github.com/italypaleale/hugo-assets v0.3.0 h1:ZH7Tq0PZz3jOYYMddis6HxFuS9NEpKwO2ah8iNHjTe4=
-github.com/italypaleale/hugo-assets v0.3.0/go.mod h1:LPOrOBqvZgjTDNwInR/6mrKgbDndARoTo69TXvtAgu0=
+github.com/italypaleale/hugo-assets v0.3.1 h1:/cvHfeYQhR9DYiU2Gf+OZB1Y54xF9u3+iPeU8toTARQ=
+github.com/italypaleale/hugo-assets v0.3.1/go.mod h1:LPOrOBqvZgjTDNwInR/6mrKgbDndARoTo69TXvtAgu0=

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -38,6 +38,7 @@ enableRobotsTXT = true
   github_url = "https://github.com/ItalyPaleAle/revaulter"
   github_repo = "https://github.com/ItalyPaleAle/revaulter"
   github_branch = "main"
+  github_path = "docs"
   PlausibleAnalytics = true
 
   [params.robots]


### PR DESCRIPTION
## Summary
- Bump the pinned `hugo-assets` docs theme from v0.3.0 to [v0.3.1](https://github.com/ItalyPaleAle/hugo-assets/releases/tag/v0.3.1) (commit `d82afca3d5ae6b89e2dc5ff275771ea05b8db1ec`)
- Per the release notes, set `github.path: "docs"` in `docs/config.json` since this project's docs live under `/docs`, so "Edit this page on GitHub" links point at the right sub-path
- Regenerate `docs/hugo.toml` to include the new `github_path` param

## Test plan
- [ ] CI build of the docs site passes
- [ ] Spot-check an "Edit this page on GitHub" link on the deployed preview points at `docs/content/...` instead of the repo root

---
_Generated by [Claude Code](https://claude.ai/code/session_017GVmdGjZsZboUDUmsuGyTT)_