### PR TITLE
chore: update hugo-assets to v0.3.2

### DIFF
--- a/docs/go.mod
+++ b/docs/go.mod
@@ -4,4 +4,4 @@ go 1.26.3
 
 tool github.com/italypaleale/hugo-assets/cmd/vercel-docs-build
 
-require github.com/italypaleale/hugo-assets v0.3.1 // indirect
+require github.com/italypaleale/hugo-assets v0.3.2 // indirect

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -1,2 +1,2 @@
-github.com/italypaleale/hugo-assets v0.3.1 h1:/cvHfeYQhR9DYiU2Gf+OZB1Y54xF9u3+iPeU8toTARQ=
-github.com/italypaleale/hugo-assets v0.3.1/go.mod h1:LPOrOBqvZgjTDNwInR/6mrKgbDndARoTo69TXvtAgu0=
+github.com/italypaleale/hugo-assets v0.3.2 h1:smWhO8H9YKak5bbxK4fmFC8flM1JqDIG8i2GhMsImmg=
+github.com/italypaleale/hugo-assets v0.3.2/go.mod h1:LPOrOBqvZgjTDNwInR/6mrKgbDndARoTo69TXvtAgu0=


### PR DESCRIPTION
## Summary
- Bumps the pinned `hugo-assets` Hugo module (`docs/go.mod` / `docs/go.sum`) from `v0.3.1` to `v0.3.2`
- Release: [v0.3.2](https://github.com/ItalyPaleAle/hugo-assets/releases/tag/v0.3.2), commit `1407812e2c917653923a15b3667c3ce66665b74c`
- No other changes required by the release notes

## Test plan
- [x] `go get github.com/italypaleale/hugo-assets@v0.3.2 && go mod tidy` run inside `docs/`, verified `go.sum` only contains the new version's hashes

---
_Generated by [Claude Code](https://claude.ai/code/session_01CkUJ4gR4pWUJcfqe2RJvRz)_