### PR TITLE
chore: update hugo-assets to v0.4.1

### DIFF
--- a/docs/go.mod
+++ b/docs/go.mod
@@ -4,4 +4,4 @@ go 1.26.3
 
 tool github.com/italypaleale/hugo-assets/cmd/vercel-docs-build
 
-require github.com/italypaleale/hugo-assets v0.4.0 // indirect
+require github.com/italypaleale/hugo-assets v0.4.1 // indirect

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -1,2 +1,2 @@
-github.com/italypaleale/hugo-assets v0.4.0 h1:l4fl7tWJzWycUuuS0DZrTnlRbCFRsoFiYkJTMTiQsj4=
-github.com/italypaleale/hugo-assets v0.4.0/go.mod h1:LPOrOBqvZgjTDNwInR/6mrKgbDndARoTo69TXvtAgu0=
+github.com/italypaleale/hugo-assets v0.4.1 h1:QcUhhqo1mgDn6MbYYeer7HF611JtspRyPE3ifPuirzI=
+github.com/italypaleale/hugo-assets v0.4.1/go.mod h1:LPOrOBqvZgjTDNwInR/6mrKgbDndARoTo69TXvtAgu0=


### PR DESCRIPTION
Updates the pinned `github.com/italypaleale/hugo-assets` module in `docs/go.mod`/`docs/go.sum` from `v0.4.0` to `v0.4.1` ([release notes](https://github.com/ItalyPaleAle/hugo-assets/releases/tag/v0.4.1), commit `4e9b53e67271a07b8fd0f3c93d593854983a19e2`).

Release notes: "Bug fixes" — no additional migration steps required.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NnpJ8qrqdWjRxdJyz9iiMM)_