### PR TITLE
Run the E2E suite on Firefox and WebKit too

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,6 +98,8 @@ jobs:
 
       - name: Install Playwright browsers
         working-directory: client/web
+        env:
+          E2E_BROWSERS: all
         run: |
           pnpm run e2e:install
 
@@ -111,14 +113,19 @@ jobs:
         run: |
           pnpm run e2e:build-server
 
+      # Every browser engine runs against SQLite
       - name: Run E2E tests (SQLite)
         working-directory: client/web
+        env:
+          E2E_BROWSERS: all
         run: |
           pnpm exec playwright test
 
+      # The Postgres run covers chromium only
       - name: Run E2E tests (Postgres)
         working-directory: client/web
         env:
           E2E_DATABASE_DSN: ${{ env.TEST_POSTGRES_DSN }}
+          E2E_BROWSERS: chromium
         run: |
           pnpm exec playwright test

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,8 @@ client-lint:
 test-client:
 	(cd client/web && pnpm run test)
 
+# Runs against chromium only
+# Set E2E_BROWSERS to "all", or to a comma-separated list of chromium, firefox and webkit, to run against other engines
 .PHONY: test-e2e
 test-e2e:
 	(cd client/web && pnpm run e2e)

--- a/client/web/e2e/browsers.mjs
+++ b/client/web/e2e/browsers.mjs
@@ -1,0 +1,34 @@
+import process from 'node:process'
+
+// Every browser engine the E2E suite can run against
+export const SUPPORTED_BROWSERS = ['chromium', 'firefox', 'webkit']
+
+// Resolves which engines to run, from the E2E_BROWSERS environment variable
+// The default is chromium alone so a local `make test-e2e` stays fast, and the other engines are opt-in
+// Accepts a comma-separated list of engine names, or "all"
+export function resolveBrowsers(value = process.env.E2E_BROWSERS) {
+    const raw = (value ?? '').trim().toLowerCase()
+    if (raw === '') {
+        return ['chromium']
+    }
+    if (raw === 'all') {
+        return [...SUPPORTED_BROWSERS]
+    }
+
+    const names = raw
+        .split(',')
+        .map((name) => name.trim())
+        .filter((name) => name !== '')
+    const unsupported = names.filter((name) => !SUPPORTED_BROWSERS.includes(name))
+    if (unsupported.length > 0) {
+        throw new Error(
+            `Unsupported E2E_BROWSERS value ${unsupported.join(', ')}: expected "all" or a comma-separated list of ${SUPPORTED_BROWSERS.join(', ')}`
+        )
+    }
+    if (names.length === 0) {
+        return ['chromium']
+    }
+
+    // Preserve the canonical order so reports read the same however the variable was written
+    return SUPPORTED_BROWSERS.filter((name) => names.includes(name))
+}

--- a/client/web/e2e/install-browsers.mjs
+++ b/client/web/e2e/install-browsers.mjs
@@ -1,0 +1,15 @@
+import { spawnSync } from 'node:child_process'
+import process from 'node:process'
+
+import { resolveBrowsers } from './browsers.mjs'
+
+// Installs only the browsers the suite is configured to run, so the default local setup does not download engines it never uses
+const browsers = resolveBrowsers()
+const result = spawnSync('playwright', ['install', '--with-deps', ...browsers], { stdio: 'inherit' })
+
+if (result.error) {
+    console.error(`Failed to run playwright install: ${result.error.message}`)
+    process.exit(1)
+}
+
+process.exit(result.status ?? 1)

--- a/client/web/e2e/multi-passkey.spec.js
+++ b/client/web/e2e/multi-passkey.spec.js
@@ -66,7 +66,9 @@ async function runDecryptThroughUI(page, requestKey, encryptOutput, noteSuffix) 
     return result.json
 }
 
-test('two passkeys without a password can each sign in and share the primary key', async ({ page }) => {
+test('two passkeys without a password can each sign in and share the primary key', { tag: '@requeststream' }, async ({
+    page,
+}) => {
     const manager = await createPasskeyManager(page)
 
     try {
@@ -100,7 +102,9 @@ test('two passkeys without a password can each sign in and share the primary key
     }
 })
 
-test('two passkeys with a password set before the second passkey share the primary key', async ({ page }) => {
+test('two passkeys with a password set before the second passkey share the primary key', {
+    tag: '@requeststream',
+}, async ({ page }) => {
     const manager = await createPasskeyManager(page)
 
     try {
@@ -143,9 +147,9 @@ test('two passkeys with a password set before the second passkey share the prima
     }
 })
 
-test('changing the password on one passkey leaves the other on the old password until it is refreshed', async ({
-    page,
-}) => {
+test('changing the password on one passkey leaves the other on the old password until it is refreshed', {
+    tag: '@requeststream',
+}, async ({ page }) => {
     const manager = await createPasskeyManager(page)
 
     try {

--- a/client/web/e2e/passkey-algorithms.spec.js
+++ b/client/web/e2e/passkey-algorithms.spec.js
@@ -92,7 +92,7 @@ for (const algorithmName of ALGORITHMS) {
             }
         })
 
-        test('approves an encrypt request end to end', async ({ page }) => {
+        test('approves an encrypt request end to end', { tag: '@requeststream' }, async ({ page }) => {
             const passkey = await installSoftwareAuthenticator(page, { algorithm: algorithmName })
 
             try {

--- a/client/web/e2e/passkeys.mjs
+++ b/client/web/e2e/passkeys.mjs
@@ -1,9 +1,16 @@
-// Manages virtual WebAuthn authenticators in Chrome for tests that need a single passkey
-// The returned object owns a CDP session that lives for the lifetime of the test
+import { installSoftwareAuthenticators } from './software-authenticator.mjs'
+
+// Manages virtual authenticators for tests that need a passkey
+// These are backed by the software authenticator in ./software-authenticator.mjs rather than Chrome's built-in virtual authenticator (which is only reachable over CDP and so only works on Chromium, plus it doesn't support any algorithm except ECDSA)
+// Every engine Playwright drives runs the same passkey ceremonies this way
+
+// Creates a page's authenticator holding a single passkey
 export async function createVirtualPasskey(page, options = {}) {
     const manager = await createVirtualPasskeyManager(page)
-    await manager.addAuthenticator({ ...options, active: true })
+    const authenticatorId = await manager.addAuthenticator({ ...options, active: true })
+    await manager.setActive(authenticatorId)
     return {
+        authenticatorId,
         async dispose() {
             await manager.dispose()
         },
@@ -13,61 +20,31 @@ export async function createVirtualPasskey(page, options = {}) {
 // Returns a manager that can host multiple virtual authenticators on the same page
 // The caller can add more authenticators on demand and toggle which one is active for ceremonies that need a specific credential
 export async function createVirtualPasskeyManager(page) {
-    const cdpSession = await page.context().newCDPSession(page)
-    await cdpSession.send('WebAuthn.enable')
+    const set = await installSoftwareAuthenticators(page)
 
-    const authenticatorIds = []
-
+    // hasPrf mirrors the option Chrome's virtual authenticator took, and algorithm picks the credential algorithm the passkey is minted with
     async function addAuthenticator(options = {}) {
-        // Chrome limits the environment to a single "internal" virtual authenticator, so only the first authenticator uses it
-        // Subsequent authenticators default to "usb" which still supports resident keys, PRF, and user verification in the virtual authenticator
-        const transport = options.transport ?? (authenticatorIds.length === 0 ? 'internal' : 'usb')
-        const result = await cdpSession.send('WebAuthn.addVirtualAuthenticator', {
-            options: {
-                protocol: 'ctap2',
-                ctap2Version: 'ctap2_1',
-                transport,
-                hasResidentKey: true,
-                hasUserVerification: true,
-                hasPrf: options.hasPrf ?? true,
-                isUserVerified: true,
-                automaticPresenceSimulation: !!options.active,
-            },
+        const authenticator = set.add({
+            algorithm: options.algorithm,
+            supportsPrf: options.hasPrf ?? true,
+            transports: options.transport ? [options.transport] : undefined,
+            active: !!options.active,
         })
-        authenticatorIds.push(result.authenticatorId)
-        return result.authenticatorId
+        return authenticator.id
     }
 
-    // Toggles the automatic presence simulation so only the specified authenticator responds to WebAuthn ceremonies
-    // All other authenticators are silenced, which in practice forces Chrome to use the active one
+    // Makes the specified authenticator the only one that responds to WebAuthn ceremonies
     async function setActive(activeId) {
-        for (const id of authenticatorIds) {
-            await cdpSession.send('WebAuthn.setAutomaticPresenceSimulation', {
-                authenticatorId: id,
-                enabled: id === activeId,
-            })
-        }
+        set.setActive(activeId)
     }
 
     // Silences every authenticator so no WebAuthn call succeeds until one is explicitly reactivated
     async function silenceAll() {
-        for (const id of authenticatorIds) {
-            await cdpSession.send('WebAuthn.setAutomaticPresenceSimulation', {
-                authenticatorId: id,
-                enabled: false,
-            })
-        }
+        set.silenceAll()
     }
 
     async function dispose() {
-        try {
-            for (const id of authenticatorIds) {
-                // Ignore errors
-                await cdpSession.send('WebAuthn.removeVirtualAuthenticator', { authenticatorId: id }).catch(() => null)
-            }
-        } finally {
-            await cdpSession.send('WebAuthn.disable').catch(() => null)
-        }
+        set.enabled = false
     }
 
     return {
@@ -76,7 +53,7 @@ export async function createVirtualPasskeyManager(page) {
         silenceAll,
         dispose,
         get authenticatorIds() {
-            return [...authenticatorIds]
+            return set.authenticators.map((authenticator) => authenticator.id)
         },
     }
 }

--- a/client/web/e2e/requests.spec.js
+++ b/client/web/e2e/requests.spec.js
@@ -33,7 +33,7 @@ test('empty ready state is shown when there are no requests', async ({ page }) =
     }
 })
 
-test('seeded encrypt request appears in the list', async ({ page, request }) => {
+test('seeded encrypt request appears in the list', { tag: '@requeststream' }, async ({ page, request }) => {
     const auth = await registerAndReachReady(page, 'Request User')
     await seedPendingRequest(request, {
         userId: auth.session.userId,
@@ -54,7 +54,7 @@ test('seeded encrypt request appears in the list', async ({ page, request }) => 
     }
 })
 
-test('seeded decrypt request appears in the list', async ({ page, request }) => {
+test('seeded decrypt request appears in the list', { tag: '@requeststream' }, async ({ page, request }) => {
     const auth = await registerAndReachReady(page, 'Request User')
     await seedPendingRequest(request, {
         userId: auth.session.userId,
@@ -72,7 +72,10 @@ test('seeded decrypt request appears in the list', async ({ page, request }) => 
     }
 })
 
-test('canceling a pending request removes it from the UI and updates state', async ({ page, request }) => {
+test('canceling a pending request removes it from the UI and updates state', { tag: '@requeststream' }, async ({
+    page,
+    request,
+}) => {
     const auth = await registerAndReachReady(page, 'Request User')
     const seeded = await seedPendingRequest(request, {
         userId: auth.session.userId,
@@ -93,10 +96,9 @@ test('canceling a pending request removes it from the UI and updates state', asy
     }
 })
 
-test('second long-poll subscriber evicts the first and the response is unavailable to the evicted caller', async ({
-    page,
-    request,
-}) => {
+test('second long-poll subscriber evicts the first and the response is unavailable to the evicted caller', {
+    tag: '@requeststream',
+}, async ({ page, request }) => {
     const auth = await registerAndReachReady(page, 'Subscriber Evict User')
 
     try {
@@ -151,7 +153,7 @@ test('second long-poll subscriber evicts the first and the response is unavailab
     }
 })
 
-test('requests for another user are not shown', async ({ page, request }) => {
+test('requests for another user are not shown', { tag: '@requeststream' }, async ({ page, request }) => {
     const auth = await registerAndReachReady(page, 'Request User')
     await seedUser(request, {
         userId: 'other-user',
@@ -175,7 +177,10 @@ test('requests for another user are not shown', async ({ page, request }) => {
     }
 })
 
-test('new seeded request appears without reload after stream is connected', async ({ page, request }) => {
+test('new seeded request appears without reload after stream is connected', { tag: '@requeststream' }, async ({
+    page,
+    request,
+}) => {
     const auth = await registerAndReachReady(page, 'Request User')
 
     try {
@@ -225,7 +230,9 @@ test('regenerating the request key invalidates the old public key endpoint', asy
     }
 })
 
-test('cli sign round-trips and the signature verifies against the browser-derived public key', async ({ page }) => {
+test('cli sign round-trips and the signature verifies against the browser-derived public key', {
+    tag: '@requeststream',
+}, async ({ page }) => {
     const auth = await registerAndReachReady(page, 'CLI Sign User')
 
     // Create a temp file with known content; CLI will SHA-256 it internally and request the browser to sign the digest
@@ -291,7 +298,9 @@ test('cli sign round-trips and the signature verifies against the browser-derive
 // Cover all four accepted name forms — both the JOSE-style and long-form name pair for AES-GCM and ChaCha20-Poly1305
 // Encrypt and decrypt must use the SAME spelling because the algorithm string is bound into HKDF info and AAD verbatim
 for (const algorithm of ['A256GCM', 'aes-256-gcm', 'C20P', 'chacha20-poly1305']) {
-    test(`cli encrypt then decrypt round-trips hello world (algorithm=${algorithm})`, async ({ page }) => {
+    test(`cli encrypt then decrypt round-trips hello world (algorithm=${algorithm})`, {
+        tag: '@requeststream',
+    }, async ({ page }) => {
         const auth = await registerAndReachReady(page, `CLI Crypto User ${algorithm}`)
 
         try {

--- a/client/web/e2e/software-authenticator.mjs
+++ b/client/web/e2e/software-authenticator.mjs
@@ -33,6 +33,20 @@ function toBase64Url(value) {
     return Buffer.from(value).toString('base64url')
 }
 
+// Resolves the relying-party ID a ceremony runs against
+// The Credentials API defaults it to the effective domain of the caller's origin, which is what the app relies on when it omits the field
+function effectiveRpID(request, explicit) {
+    if (explicit) {
+        return explicit
+    }
+
+    try {
+        return new URL(request.origin).hostname
+    } catch {
+        throw new AuthenticatorError('NotSupportedError', `Cannot derive an rpId from origin ${request.origin}`)
+    }
+}
+
 // Errors carrying a DOMException name so the page shim can rethrow them the way the Credentials API would
 class AuthenticatorError extends Error {
     constructor(name, message) {
@@ -41,51 +55,32 @@ class AuthenticatorError extends Error {
     }
 }
 
+// One virtual authenticator holding its own credentials
+// A page can host several of them, which is how tests cover accounts with more than one passkey
 export class SoftwareAuthenticator {
-    constructor(options = {}) {
+    constructor(id, options = {}) {
+        this.id = id
         this.algorithm = getPasskeyAlgorithm(options.algorithm ?? 'es256')
         // A "PRF-less" authenticator is useful for asserting the client's error path, matching the virtual authenticator's hasPrf option
         this.supportsPrf = options.supportsPrf ?? true
+        this.transports = options.transports ?? ['internal', 'hybrid']
+        // Only an active authenticator answers a ceremony, standing in for the presence the user would supply on a real one
+        this.active = options.active ?? false
         this.credentials = new Map()
-        this.enabled = true
     }
 
     get credentialCount() {
         return this.credentials.size
     }
 
-    // Handles one request forwarded from the page shim
-    // Errors are returned rather than thrown so Playwright's binding does not turn them into an opaque rejection
-    async handle(request) {
-        if (!this.enabled) {
-            return { error: { name: 'NotAllowedError', message: 'The software authenticator was disposed' } }
-        }
-
-        try {
-            switch (request?.kind) {
-                case 'create':
-                    return { result: this.create(request) }
-                case 'get':
-                    return { result: this.get(request) }
-                default:
-                    throw new AuthenticatorError('NotSupportedError', `Unsupported request: ${request?.kind}`)
-            }
-        } catch (err) {
-            return {
-                error: {
-                    name: err instanceof AuthenticatorError ? err.domName : 'NotAllowedError',
-                    message: err instanceof Error ? err.message : String(err),
-                },
-            }
-        }
+    // Reports whether this authenticator holds a credential that could answer a request
+    canAnswer(rpID, allowCredentials) {
+        return this.selectCredential(rpID, allowCredentials) !== null
     }
 
     create(request) {
         const publicKey = request.publicKey ?? {}
-        const rpID = publicKey.rp?.id
-        if (!rpID) {
-            throw new AuthenticatorError('NotSupportedError', 'Creation options are missing rp.id')
-        }
+        const rpID = effectiveRpID(request, publicKey.rp?.id)
 
         // Honor the relying party's algorithm preferences: a real authenticator only mints a credential the RP asked for
         const params = Array.isArray(publicKey.pubKeyCredParams) ? publicKey.pubKeyCredParams : []
@@ -142,7 +137,7 @@ export class SoftwareAuthenticator {
                 clientDataJSON: toBase64Url(clientDataJSON),
                 attestationObject: toBase64Url(attestationObject),
                 authenticatorData: toBase64Url(authData),
-                transports: ['internal', 'hybrid'],
+                transports: [...this.transports],
                 publicKeyAlgorithm: this.algorithm.coseAlgorithm,
             },
             clientExtensionResults: this.supportsPrf ? { prf: { enabled: true } } : {},
@@ -151,12 +146,9 @@ export class SoftwareAuthenticator {
 
     get(request) {
         const publicKey = request.publicKey ?? {}
-        const rpID = publicKey.rpId
-        if (!rpID) {
-            throw new AuthenticatorError('NotSupportedError', 'Request options are missing rpId')
-        }
+        const rpID = effectiveRpID(request, publicKey.rpId)
 
-        const credential = this.#selectCredential(rpID, publicKey.allowCredentials)
+        const credential = this.selectCredential(rpID, publicKey.allowCredentials)
         if (!credential) {
             throw new AuthenticatorError('NotAllowedError', 'No credential is available for this relying party')
         }
@@ -184,7 +176,7 @@ export class SoftwareAuthenticator {
     }
 
     // Picks the credential that answers a request, honoring allowCredentials when the relying party restricts the set
-    #selectCredential(rpID, allowCredentials) {
+    selectCredential(rpID, allowCredentials) {
         const allowed = Array.isArray(allowCredentials) ? allowCredentials : []
         if (allowed.length > 0) {
             for (const descriptor of allowed) {
@@ -382,7 +374,7 @@ function installShim({ bindingName }) {
         }
     }
 
-    navigator.credentials.create = async (options) => {
+    const create = async (options) => {
         return buildCredential(
             await callAuthenticator({
                 kind: 'create',
@@ -392,7 +384,7 @@ function installShim({ bindingName }) {
         )
     }
 
-    navigator.credentials.get = async (options) => {
+    const get = async (options) => {
         return buildCredential(
             await callAuthenticator({
                 kind: 'get',
@@ -401,25 +393,138 @@ function installShim({ bindingName }) {
             })
         )
     }
+
+    // WebKit's Linux build defines PublicKeyCredential but no navigator.credentials at all, so the container has to be created before its methods can be replaced
+    if (navigator.credentials) {
+        navigator.credentials.create = create
+        navigator.credentials.get = get
+    } else {
+        Object.defineProperty(navigator, 'credentials', {
+            configurable: true,
+            value: { create, get },
+        })
+    }
 }
 
-let bindingCounter = 0
+// The set of virtual authenticators attached to one page, which is what the page shim talks to
+// Routing a ceremony to the active authenticator is what lets a test choose which passkey answers
+export class SoftwareAuthenticatorSet {
+    constructor() {
+        this.authenticators = []
+        this.enabled = true
+        this.#nextID = 1
+    }
 
-// Installs a software authenticator on a page for the lifetime of a test
-// The authenticator must be installed before the page navigates to the app, because the shim is applied to new documents
-export async function installSoftwareAuthenticator(page, options = {}) {
-    const authenticator = new SoftwareAuthenticator(options)
-    bindingCounter++
-    const bindingName = `__revaulterSoftwareAuthenticator${bindingCounter}`
+    #nextID
 
-    await page.exposeFunction(bindingName, (request) => authenticator.handle(request))
+    add(options = {}) {
+        const authenticator = new SoftwareAuthenticator(`software-authenticator-${this.#nextID++}`, options)
+        this.authenticators.push(authenticator)
+        return authenticator
+    }
+
+    get(id) {
+        return this.authenticators.find((authenticator) => authenticator.id === id) ?? null
+    }
+
+    // Makes one authenticator the only active one, which is how a test picks the passkey a ceremony uses
+    setActive(id) {
+        for (const authenticator of this.authenticators) {
+            authenticator.active = authenticator.id === id
+        }
+    }
+
+    // Silences every authenticator so no ceremony succeeds until one is reactivated
+    silenceAll() {
+        for (const authenticator of this.authenticators) {
+            authenticator.active = false
+        }
+    }
+
+    // Handles one request forwarded from the page shim
+    // Errors are returned rather than thrown so Playwright's binding does not turn them into an opaque rejection
+    async handle(request) {
+        try {
+            if (!this.enabled) {
+                throw new AuthenticatorError('NotAllowedError', 'The software authenticators were disposed')
+            }
+
+            switch (request?.kind) {
+                case 'create':
+                    return { result: this.#responder(request).create(request) }
+                case 'get':
+                    return { result: this.#responder(request).get(request) }
+                default:
+                    throw new AuthenticatorError('NotSupportedError', `Unsupported request: ${request?.kind}`)
+            }
+        } catch (err) {
+            return {
+                error: {
+                    name: err instanceof AuthenticatorError ? err.domName : 'NotAllowedError',
+                    message: err instanceof Error ? err.message : String(err),
+                },
+            }
+        }
+    }
+
+    // Chooses the authenticator that answers a ceremony among the active ones
+    #responder(request) {
+        const active = this.authenticators.filter((authenticator) => authenticator.active)
+        if (active.length === 0) {
+            throw new AuthenticatorError('NotAllowedError', 'No active authenticator is available')
+        }
+
+        // An assertion has to come from an authenticator that actually holds a matching credential, the way a real one only responds when it can
+        if (request.kind === 'get') {
+            const publicKey = request.publicKey ?? {}
+            const rpID = effectiveRpID(request, publicKey.rpId)
+            const holder = active.find((authenticator) => authenticator.canAnswer(rpID, publicKey.allowCredentials))
+            if (!holder) {
+                throw new AuthenticatorError('NotAllowedError', 'No active authenticator holds a matching credential')
+            }
+            return holder
+        }
+
+        // A registration goes to the most recently activated authenticator
+        return active[active.length - 1]
+    }
+}
+
+const installed = new WeakMap()
+
+// Attaches the page shim and its binding once per page, so several authenticators can share one page the way a browser profile would
+async function attachToPage(page) {
+    const existing = installed.get(page)
+    if (existing) {
+        return existing
+    }
+
+    const set = new SoftwareAuthenticatorSet()
+    const bindingName = '__revaulterSoftwareAuthenticator'
+    await page.exposeFunction(bindingName, (request) => set.handle(request))
     await page.addInitScript(installShim, { bindingName })
+    installed.set(page, set)
+    return set
+}
+
+// Returns the set of software authenticators for a page, creating it on first use
+// It must be installed before the page navigates to the app, because the shim is applied to new documents
+export async function installSoftwareAuthenticators(page) {
+    return attachToPage(page)
+}
+
+// Installs a single software authenticator and makes it the active one
+export async function installSoftwareAuthenticator(page, options = {}) {
+    const set = await attachToPage(page)
+    const authenticator = set.add({ ...options, active: true })
+    set.setActive(authenticator.id)
 
     return {
+        set,
         authenticator,
         algorithm: authenticator.algorithm,
         async dispose() {
-            authenticator.enabled = false
+            set.enabled = false
         },
     }
 }

--- a/client/web/e2e/ssh-agent.spec.js
+++ b/client/web/e2e/ssh-agent.spec.js
@@ -19,7 +19,9 @@ test.beforeEach(async ({ page, request }) => {
     await resetBrowserState(page)
 })
 
-test('ssh-agent serves the public key and approves SSH auth through Revaulter', async ({ page }) => {
+test('ssh-agent serves the public key and approves SSH auth through Revaulter', { tag: '@requeststream' }, async ({
+    page,
+}) => {
     const auth = await registerAndReachReady(page, 'SSH Agent User')
     const tmpRoot = mkdtempSync(join(tmpdir(), 'revaulter-e2e-ssh-agent-'))
     const trustStorePath = join(tmpRoot, 'trust.json')

--- a/client/web/package.json
+++ b/client/web/package.json
@@ -10,7 +10,7 @@
     "e2e": "pnpm run e2e:build-server && playwright test",
     "e2e:build-server": "vite build --mode e2e && mkdir -p ../../.bin && go build -tags e2e -o ../../.bin/revaulter-e2e ../../cmd/revaulter",
     "e2e:headed": "pnpm run e2e:build-server && playwright test --headed",
-    "e2e:install": "playwright install --with-deps chromium",
+    "e2e:install": "node ./e2e/install-browsers.mjs",
     "format": "biome format --write .",
     "lint": "biome lint . && svelte-check",
     "lint:biome": "biome lint .",

--- a/client/web/playwright.config.js
+++ b/client/web/playwright.config.js
@@ -1,9 +1,39 @@
 import process from 'node:process'
 import { defineConfig, devices } from '@playwright/test'
 
+import { resolveBrowsers } from './e2e/browsers.mjs'
+
 const port = 41741
 const baseURL = `http://localhost:${port}`
 const e2eToken = process.env.REVAULTER_E2E_TOKEN || 'playwright-e2e-token-fixed'
+
+const browserProjects = {
+    chromium: {
+        name: 'chromium',
+        use: {
+            ...devices['Desktop Chrome'],
+            headless: true,
+        },
+    },
+    firefox: {
+        name: 'firefox',
+        use: {
+            ...devices['Desktop Firefox'],
+            headless: true,
+        },
+    },
+    webkit: {
+        name: 'webkit',
+        use: {
+            ...devices['Desktop Safari'],
+            headless: true,
+        },
+        // Playwright's WebKit build surfaces only the first ~128 bytes of a streaming response body, holding the rest until the next write or until the response ends
+        // A pending request arriving on the otherwise idle list stream is therefore never delivered as a whole line, so tests that wait for one to appear cannot pass here
+        // This is a limitation of the test browser: the same server response streams correctly in Safari on macOS and iOS
+        grepInvert: /@requeststream/,
+    },
+}
 
 export default defineConfig({
     testDir: './e2e',
@@ -18,15 +48,7 @@ export default defineConfig({
         screenshot: 'only-on-failure',
         video: 'retain-on-failure',
     },
-    projects: [
-        {
-            name: 'chromium',
-            use: {
-                ...devices['Desktop Chrome'],
-                headless: true,
-            },
-        },
-    ],
+    projects: resolveBrowsers().map((name) => browserProjects[name]),
     webServer: {
         command: `REVAULTER_E2E_TOKEN=${e2eToken} node ./e2e/start-revaulter.mjs --port=${port}`,
         url: `${baseURL}/healthz`,


### PR DESCRIPTION
The virtual authenticators are now backed by the software authenticator (`software-authenticator.mjs`), which works on Firefox and WebKit too.